### PR TITLE
fix: Add command to run playground from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
     "test:integration": "turbo run test:watch",
-    "build": "turbo run build"
+    "build": "turbo run build",
+    "run:playground": "pnpm --filter=playground dev"
   },
   "packageManager": "pnpm@8.5.1"
 }


### PR DESCRIPTION
Closes #167 

Use "pnpm run:playground" to launch playground from root folder.