### PR TITLE
feature(xcm-analyser): Add XCM Analyser package to monorepo

### DIFF
--- a/packages/xcm-analyser/.eslintrc.json
+++ b/packages/xcm-analyser/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["standard-with-typescript", "prettier"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/packages/xcm-analyser/.prettierrc.json
+++ b/packages/xcm-analyser/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/packages/xcm-analyser/LICENSE
+++ b/packages/xcm-analyser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 ParaSpell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/xcm-analyser/package.json
+++ b/packages/xcm-analyser/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@paraspell/xcm-analyser",
+  "version": "1.0.0",
+  "description": "Tool for converting XCM MultiLocation into human readable written format.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "compile": "tsc --noEmit",
+    "build": "rollup -c",
+    "lint:check": "eslint src --ext .ts",
+    "lint": "eslint --fix src --ext .ts",
+    "format:check": "prettier --check src",
+    "format:write": "prettier --write src",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:cov": "vitest run --coverage --config ./vitest.config.coverage.ts",
+    "runAll": "pnpm compile && pnpm format:write && pnpm lint && pnpm test",
+    "release": "pnpm runAll && pnpm build && standard-version && git push --follow-tags",
+    "runExample": "TS_NODE_PROJECT='./tsconfig.node.json' node --loader ts-node/esm --experimental-specifier-resolution=node ./scripts/example.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-json": "^6.0.1",
+    "rollup": "^4.2.0",
+    "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-typescript2": "^0.36.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.2.2"
+  },
+  "packageManager": "pnpm@8.5.1"
+}

--- a/packages/xcm-analyser/rollup.config.js
+++ b/packages/xcm-analyser/rollup.config.js
@@ -1,0 +1,27 @@
+import typescript from 'rollup-plugin-typescript2';
+import json from '@rollup/plugin-json';
+import dts from 'rollup-plugin-dts';
+import { babel } from '@rollup/plugin-babel';
+
+export default [
+  {
+    input: './src/index.ts',
+    external: ['ms'],
+    output: [{ file: './dist/index.mjs', format: 'esm' }],
+    plugins: [
+      typescript(),
+      json(),
+      babel({
+        extensions: ['.ts'],
+        plugins: ['@babel/plugin-syntax-import-assertions'],
+        babelHelpers: 'bundled',
+        presets: ['@babel/preset-env'],
+      }),
+    ],
+  },
+  {
+    input: './src/index.ts',
+    output: [{ file: './dist/index.d.ts', format: 'esm' }],
+    plugins: [dts()],
+  },
+];

--- a/packages/xcm-analyser/scripts/example.ts
+++ b/packages/xcm-analyser/scripts/example.ts
@@ -1,0 +1,43 @@
+import { MultiLocation } from '../src/types';
+import { convertMultilocationToUrl, convertXCMToUrls } from '../src/converter/convert';
+
+const multilocation: MultiLocation = {
+  parents: '1',
+  interior: {
+    X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+  },
+};
+
+const url = convertMultilocationToUrl(multilocation);
+
+console.log();
+console.log(`URL: ${url}`);
+
+// ParaToPara - Basilisk -> BifrostKusama xTokens.transfer arguments
+const xcmCallArguments = [
+  '1', // currency_id for KSM
+  '100000000000', // amount - 0.1 KSM
+  {
+    // dest
+    V3: {
+      parents: '1',
+      interior: {
+        X2: [
+          {
+            Parachain: '2001', // BifrostKusama paraId
+          },
+          {
+            AccountId32: {
+              network: null,
+              id: '0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b',
+            },
+          },
+        ],
+      },
+    },
+  },
+  'Unlimited', // dest_weight_limit
+];
+
+const urls = convertXCMToUrls(xcmCallArguments);
+console.log(`URLs: ${urls}`);

--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+import { type MultiLocation } from '../types';
+import { convertMultilocationToUrl, convertXCMToUrls } from './convert';
+import { ZodError } from 'zod';
+
+describe('convert', () => {
+  it('convert multilocation to URL', () => {
+    const multilocation: MultiLocation = {
+      parents: '0',
+      interior: {
+        X2: [
+          {
+            PalletInstance: '50',
+          },
+          {
+            GeneralIndex: '41',
+          },
+        ],
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('./PalletInstance(50)/GeneralIndex(41)');
+  });
+
+  it('convert multilocation to URL with parents', () => {
+    const multilocation: MultiLocation = {
+      parents: '3',
+      interior: {
+        X2: [
+          {
+            PalletInstance: '50',
+          },
+          {
+            GeneralIndex: '41',
+          },
+        ],
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('../../../PalletInstance(50)/GeneralIndex(41)');
+  });
+
+  it('convert multilocation to URL with parachain interior', () => {
+    const multilocation: MultiLocation = {
+      parents: '1',
+      interior: {
+        X1: {
+          Parachain: '2006',
+        },
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('../Parachain(2006)');
+  });
+
+  it('convert multilocation to URL with account interior', () => {
+    const multilocation: MultiLocation = {
+      parents: '0',
+      interior: {
+        X1: {
+          AccountId32: {
+            network: null,
+            id: 'accountID',
+          },
+        },
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('./AccountId32(null, accountID)');
+  });
+
+  it('convert multilocation to URL with currency and amout multilocation', () => {
+    const multilocation: MultiLocation = {
+      parents: '0',
+      interior: {
+        X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('./PalletInstance(50)/GeneralIndex(1984)');
+  });
+
+  it('convert multilocation to URL from tx arguments with one multilocation', () => {
+    const xcmCallArguments = [
+      '1', // currency_id for KSM
+      '100000000000', // amount - 0.1 KSM
+      {
+        // dest
+        V3: {
+          parents: '1',
+          interior: {
+            X2: [
+              {
+                Parachain: '2001', // BifrostKusama paraId
+              },
+              {
+                AccountId32: {
+                  network: null,
+                  id: '0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b',
+                },
+              },
+            ],
+          },
+        },
+      },
+      'Unlimited', // dest_weight_limit
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+    expect(result).toStrictEqual([
+      '../Parachain(2001)/AccountId32(null, 0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b)',
+    ]);
+  });
+
+  it('convert multilocation to URL from tx arguments with multiple multilocations', () => {
+    const xcmCallArguments = [
+      {
+        V3: {
+          parents: '1',
+          interior: {
+            X1: {
+              Parachain: '2006',
+            },
+          },
+        },
+      },
+      {
+        V3: {
+          parents: '0',
+          interior: {
+            X1: {
+              AccountId32: {
+                network: null,
+                id: 'accountID',
+              },
+            },
+          },
+        },
+      },
+      {
+        V3: [
+          {
+            id: {
+              Concrete: {
+                parents: '0',
+                interior: {
+                  X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+                },
+              },
+            },
+            fun: {
+              Fungible: 'amount',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+    expect(result).toStrictEqual([
+      '../Parachain(2006)',
+      './AccountId32(null, accountID)',
+      './PalletInstance(50)/GeneralIndex(1984)',
+    ]);
+  });
+
+  it('convert multilocation to URL from tx arguments with no multilocations', () => {
+    const xcmCallArguments = [
+      '1', // currency_id for KSM
+      '100000000000', // amount - 0.1 KSM
+      'Unlimited', // dest_weight_limit
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+    expect(result).toStrictEqual([]);
+  });
+
+  it('convert multilocation to URL with X2 with 3 elements', () => {
+    const xcmCallArguments = [
+      {
+        V3: [
+          {
+            id: {
+              Concrete: {
+                parents: '0',
+                interior: {
+                  X2: [
+                    {
+                      Parachain: '2001', // BifrostKusama paraId
+                    },
+                    {
+                      AccountId32: {
+                        network: 'Polkadot',
+                        id: '0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b',
+                      },
+                    },
+                    {
+                      Plurality: {
+                        id: 'Unit',
+                        part: null,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            fun: {
+              Fungible: 'amount',
+            },
+          },
+        ],
+      },
+    ];
+
+    const t = (): any => {
+      convertXCMToUrls(xcmCallArguments);
+    };
+
+    expect(t).toThrowError(ZodError);
+  });
+
+  it('convert multilocation to URL with plurality', () => {
+    const xcmCallArguments = [
+      {
+        V3: [
+          {
+            id: {
+              Concrete: {
+                parents: '0',
+                interior: {
+                  X2: [
+                    {
+                      AccountId32: {
+                        network: 'Polkadot',
+                        id: '0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b',
+                      },
+                    },
+                    {
+                      Plurality: {
+                        id: 'Unit',
+                        part: null,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            fun: {
+              Fungible: 'amount',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+    expect(result).toStrictEqual([
+      './AccountId32(Polkadot, 0x84fc49ce30071ea611731838cc7736113c1ec68fbc47119be8a0805066df9b2b)/Plurality(Unit, null)',
+    ]);
+  });
+});

--- a/packages/xcm-analyser/src/converter/convert.ts
+++ b/packages/xcm-analyser/src/converter/convert.ts
@@ -1,0 +1,38 @@
+import { type Junction, type JunctionType, type MultiLocation } from '../types';
+import { convertJunctionToReadable, findMultiLocationInObject } from '../utils/utils';
+
+export const convertMultilocationToUrlJson = (multiLocationJson: string): string => {
+  const multiLocation: MultiLocation = JSON.parse(multiLocationJson);
+  return convertMultilocationToUrl(multiLocation);
+};
+
+export const convertMultilocationToUrl = ({ parents, interior }: MultiLocation): string => {
+  const parentsNum = Number(parents);
+
+  const entries = Object.entries(interior);
+  if (entries.length === 0) throw new Error('Interior is empty');
+
+  const [, junctions] = entries[0] as [JunctionType, Junction | Junction[]];
+
+  const isX1 = !Array.isArray(junctions);
+
+  if (!isX1 && junctions.length === 0) throw new Error('Junction array is empty');
+
+  const pathStart = parentsNum > 0 ? '../'.repeat(parentsNum) : './';
+  const path = (isX1 ? [junctions] : junctions)
+    .map((junction) => convertJunctionToReadable(junction))
+    .join('/');
+
+  return `${pathStart}${path}`;
+};
+
+export const convertXCMToUrls = (txArguments: any): string[] => {
+  return txArguments.flatMap((arg: any) => {
+    const multiLocation = findMultiLocationInObject(arg);
+    if (multiLocation !== null && multiLocation !== undefined) {
+      return [convertMultilocationToUrl(multiLocation)];
+    } else {
+      return [];
+    }
+  });
+};

--- a/packages/xcm-analyser/src/index.ts
+++ b/packages/xcm-analyser/src/index.ts
@@ -1,0 +1,2 @@
+export * from './converter/convert';
+export * from './types';

--- a/packages/xcm-analyser/src/types.ts
+++ b/packages/xcm-analyser/src/types.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod';
+
+export type JunctionType =
+  | 'Parachain'
+  | 'AccountId32'
+  | 'AccountIndex64'
+  | 'AccountKey20'
+  | 'PalletInstance'
+  | 'GeneralIndex'
+  | 'GeneralKey'
+  | 'OnlyChild'
+  | 'Plurality'
+  | 'GlobalConsensus';
+
+const NetworkId = z.string().nullable();
+const BodyId = z.string().nullable();
+const BodyPart = z.string().nullable();
+const StringOrNumber = z.string().regex(/^\d+$/).or(z.number()).or(z.bigint());
+const HexString = z.string();
+
+const JunctionParachain = z.object({ Parachain: StringOrNumber });
+const JunctionAccountId32 = z.object({
+  AccountId32: z.object({ network: NetworkId, id: HexString }),
+});
+const JunctionAccountIndex64 = z.object({
+  AccountIndex64: z.object({ network: NetworkId, index: StringOrNumber }),
+});
+const JunctionAccountKey20 = z.object({
+  AccountKey20: z.object({ network: NetworkId, key: HexString }),
+});
+const JunctionPalletInstance = z.object({ PalletInstance: StringOrNumber });
+const JunctionGeneralIndex = z.object({ GeneralIndex: StringOrNumber });
+const JunctionGeneralKey = z.object({
+  GeneralKey: z.object({ length: StringOrNumber, data: HexString }),
+});
+const JunctionOnlyChild = z.object({ OnlyChild: z.string() });
+const JunctionPlurality = z.object({
+  Plurality: z.object({ id: BodyId, part: BodyPart }),
+});
+const JunctionGlobalConsensus = z.object({ GlobalConsensus: NetworkId });
+
+const JunctionSchema = z.union([
+  JunctionParachain,
+  JunctionAccountId32,
+  JunctionAccountIndex64,
+  JunctionAccountKey20,
+  JunctionPalletInstance,
+  JunctionGeneralIndex,
+  JunctionGeneralKey,
+  JunctionOnlyChild,
+  JunctionPlurality,
+  JunctionGlobalConsensus,
+]);
+
+const Junctions = z.lazy(() =>
+  z.object({
+    X1: JunctionSchema.optional(),
+    X2: z.tuple([JunctionSchema, JunctionSchema]).optional(),
+    X3: z.tuple([JunctionSchema, JunctionSchema, JunctionSchema]).optional(),
+    X4: z.tuple([JunctionSchema, JunctionSchema, JunctionSchema, JunctionSchema]).optional(),
+    X5: z
+      .tuple([JunctionSchema, JunctionSchema, JunctionSchema, JunctionSchema, JunctionSchema])
+      .optional(),
+    X6: z
+      .tuple([
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+      ])
+      .optional(),
+    X7: z
+      .tuple([
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+      ])
+      .optional(),
+    X8: z
+      .tuple([
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+      ])
+      .optional(),
+    X9: z
+      .tuple([
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+      ])
+      .optional(),
+    X10: z
+      .tuple([
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+        JunctionSchema,
+      ])
+      .optional(),
+  }),
+);
+
+export const MultiLocationSchema = z.object({
+  parents: StringOrNumber,
+  interior: Junctions,
+});
+
+export type MultiLocation = z.infer<typeof MultiLocationSchema>;
+export type Junction = z.infer<typeof JunctionSchema>;

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -1,0 +1,59 @@
+import { type MultiLocation, type Junction, MultiLocationSchema } from '../types';
+
+export const convertJunctionToReadable = (junctionOriginal: Junction): string | never => {
+  const junction = Object.fromEntries(
+    Object.entries(junctionOriginal).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+
+  if ('parachain' in junction) {
+    return `Parachain(${junction.parachain})`;
+  } else if ('accountid32' in junction) {
+    return `AccountId32(${junction.accountid32.network}, ${junction.accountid32.id})`;
+  } else if ('accountindex64' in junction) {
+    return `AccountIndex64(${junction.accountindex64.network}, ${junction.accountindex64.index})`;
+  } else if ('accountkey20' in junction) {
+    return `AccountKey20(${junction.accountkey20.network}, ${junction.accountkey20.key})`;
+  } else if ('palletinstance' in junction) {
+    return `PalletInstance(${junction.palletinstance})`;
+  } else if ('generalindex' in junction) {
+    return `GeneralIndex(${junction.generalindex})`;
+  } else if ('generalkey' in junction) {
+    return `GeneralKey(${junction.generalkey.length}, ${junction.generalkey.data})`;
+  } else if ('onlychild' in junction) {
+    return `OnlyChild(${junction.onlychild})`;
+  } else if ('plurality' in junction) {
+    return `Plurality(${junction.plurality.id}, ${junction.plurality.part})`;
+  } else if ('globalconsensus' in junction) {
+    return `GlobalConsensus(${junction.globalconsensus})`;
+  }
+  console.log('junction', junction);
+  throw new Error('Unknown junction type');
+};
+
+export function findMultiLocationInObject(obj: any): MultiLocation {
+  function hasSpecificKeys(value: any): boolean {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      'parents' in value &&
+      'interior' in value
+    );
+  }
+
+  function searchObject(value: any): any {
+    if (hasSpecificKeys(value)) {
+      const parsedValue = MultiLocationSchema.parse(value);
+      return parsedValue;
+    } else if (typeof value === 'object' && value !== null) {
+      for (const key of Object.keys(value)) {
+        const result = searchObject(value[key]);
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (result) return result;
+      }
+    }
+    return null;
+  }
+
+  return searchObject(obj);
+}

--- a/packages/xcm-analyser/tsconfig.json
+++ b/packages/xcm-analyser/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/xcm-analyser/tsconfig.node.json
+++ b/packages/xcm-analyser/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": ["scripts"]
+}

--- a/packages/xcm-analyser/vitest.config.coverage.ts
+++ b/packages/xcm-analyser/vitest.config.coverage.ts
@@ -1,0 +1,9 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ['src/**/*'],
+    },
+  },
+});

--- a/packages/xcm-analyser/vitest.config.ts
+++ b/packages/xcm-analyser/vitest.config.ts
@@ -1,0 +1,5 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,6 +454,34 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/xcm-analyser:
+    dependencies:
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+    devDependencies:
+      '@rollup/plugin-babel':
+        specifier: ^6.0.4
+        version: 6.0.4(@babel/core@7.24.3)(rollup@4.13.0)
+      '@rollup/plugin-json':
+        specifier: ^6.0.1
+        version: 6.1.0(rollup@4.13.0)
+      rollup:
+        specifier: ^4.2.0
+        version: 4.13.0
+      rollup-plugin-dts:
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.13.0)(typescript@5.4.3)
+      rollup-plugin-typescript2:
+        specifier: ^0.36.0
+        version: 0.36.0(rollup@4.13.0)(typescript@5.4.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.11.30)(typescript@5.4.3)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.4.3
+
   packages/xcm-router:
     dependencies:
       '@acala-network/api':
@@ -938,9 +966,9 @@ packages:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
     dev: true
 
@@ -1094,14 +1122,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.23.0:
@@ -1109,13 +1137,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
-    dev: true
-
-  /@babel/helper-module-imports@7.22.15:
-    resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.23.9
     dev: true
 
   /@babel/helper-module-imports@7.24.3:
@@ -1133,7 +1154,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-module-imports': 7.24.3
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
@@ -1147,7 +1168,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.3
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-module-imports': 7.24.3
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
@@ -1234,7 +1255,7 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
@@ -1248,7 +1269,7 @@ packages:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/helper-string-parser@7.23.4:
@@ -1286,7 +1307,7 @@ packages:
     dependencies:
       '@babel/template': 7.23.9
       '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1326,7 +1347,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/parser@7.24.1:
@@ -1812,7 +1833,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-module-imports': 7.24.3
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.6)
     dev: true
@@ -3067,9 +3088,9 @@ packages:
     resolution: {integrity: sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.2
       '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@babel/template@7.24.0:
@@ -3085,14 +3106,14 @@ packages:
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.2
       '@babel/generator': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -4138,7 +4159,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
   /@jridgewell/gen-mapping@0.3.5:
@@ -4150,14 +4171,9 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@jridgewell/resolve-uri@3.1.1:
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
-    engines: {node: '>=6.0.0'}
-
   /@jridgewell/resolve-uri@3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
@@ -4182,7 +4198,7 @@ packages:
   /@jridgewell/trace-mapping@0.3.22:
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
@@ -4196,7 +4212,7 @@ packages:
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
   /@kiltprotocol/type-definitions@0.34.0:
@@ -7290,20 +7306,20 @@ packages:
   /@types/babel__generator@7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@types/babel__template@7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
       '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@types/babel__traverse@7.20.5:
     resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: true
 
   /@types/big.js@6.1.2:
@@ -13137,7 +13153,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -14297,9 +14313,23 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
     dependencies:
-      magic-string: 0.30.6
+      magic-string: 0.30.8
       rollup: 4.13.0
       typescript: 5.2.2
+    optionalDependencies:
+      '@babel/code-frame': 7.24.2
+    dev: true
+
+  /rollup-plugin-dts@6.1.0(rollup@4.13.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0
+    dependencies:
+      magic-string: 0.30.8
+      rollup: 4.13.0
+      typescript: 5.4.3
     optionalDependencies:
       '@babel/code-frame': 7.24.2
     dev: true
@@ -14311,7 +14341,7 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
     dependencies:
-      magic-string: 0.30.6
+      magic-string: 0.30.8
       rollup: 4.4.1
       typescript: 5.3.3
     optionalDependencies:
@@ -14331,6 +14361,21 @@ packages:
       semver: 7.6.0
       tslib: 2.6.2
       typescript: 5.2.2
+    dev: true
+
+  /rollup-plugin-typescript2@0.36.0(rollup@4.13.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
+    peerDependencies:
+      rollup: '>=1.26.3'
+      typescript: '>=2.4.0'
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      find-cache-dir: 3.3.2
+      fs-extra: 10.1.0
+      rollup: 4.13.0
+      semver: 7.6.0
+      tslib: 2.6.2
+      typescript: 5.4.3
     dev: true
 
   /rollup-plugin-typescript2@0.36.0(rollup@4.4.1)(typescript@5.3.3):
@@ -15390,6 +15435,37 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.11.30
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true


### PR DESCRIPTION
This PR adds a new package that provides functionality to convert XCM MultiLocations into human readable URLs. It parses the MultiLocation structure for different junction types. The MultiLocation type identifies any single location where `parents` describe the number of steps in the hierarchy we want to move up and `interior` expresses the steps in the hierarchy we want to move down. See [documentation](https://paritytech.github.io/xcm-docs/fundamentals/multilocation/index.html).

The following junction types are supported:
- Parachain
- AccountId32
- AccountIndex64
- AccountKey20
- PalletInstance
- GeneralIndex
- GeneralKey
- OnlyChild
- Plurality
- GlobalConsensus

Added functions:
- convertMultilocationToUrl - converts single MultiLocation object to URL
- convertMultilocationToUrlJson - converts single MultiLocation object encoded as string to URL
- convertXCMToUrls - converts XCM arguments array to an array of MultiLocations. These functions will automatically search for multilocation objects inside XCM call arguments and convert them.

Closes #188 