### PR TITLE
feat(sdk): Add MultiLocation override feature ⛓️

### DIFF
--- a/packages/sdk/src/builder/builders/Builder.ts
+++ b/packages/sdk/src/builder/builders/Builder.ts
@@ -1,7 +1,15 @@
 // Implements general builder pattern, this is Builder main file
 
 import { type ApiPromise } from '@polkadot/api'
-import { type Extrinsic, type TNode, type TSerializedApiCall } from '../../types'
+import {
+  type TAmount,
+  type Extrinsic,
+  type TNode,
+  type TSerializedApiCall,
+  type TCurrency,
+  type TDestination,
+  type TAddress
+} from '../../types'
 import CloseChannelBuilder, { type InboundCloseChannelBuilder } from './CloseChannelBuilder'
 import OpenChannelBuilder, { type MaxSizeOpenChannelBuilder } from './OpenChannelBuilder'
 import RelayToParaBuilder from './RelayToParaBuilder'
@@ -12,17 +20,17 @@ import { MissingApiPromiseError } from '../../errors/MissingApiPromiseError'
 class ToGeneralBuilder {
   private readonly api?: ApiPromise
   private readonly from: TNode
-  private readonly to: TNode
+  private readonly to: TDestination
   private readonly paraIdTo?: number
 
-  constructor(api: ApiPromise | undefined, from: TNode, to: TNode, paraIdTo?: number) {
+  constructor(api: ApiPromise | undefined, from: TNode, to: TDestination, paraIdTo?: number) {
     this.api = api
     this.from = from
     this.to = to
     this.paraIdTo = paraIdTo
   }
 
-  currency(currency: string | number | bigint): AmountBuilder {
+  currency(currency: TCurrency): AmountBuilder {
     return ParaToParaBuilder.createParaToPara(this.api, this.from, this.to, currency, this.paraIdTo)
   }
 
@@ -43,11 +51,11 @@ class FromGeneralBuilder {
     this.from = from
   }
 
-  to(node: TNode, paraIdTo?: number): ToGeneralBuilder {
+  to(node: TDestination, paraIdTo?: number): ToGeneralBuilder {
     return new ToGeneralBuilder(this.api, this.from, node, paraIdTo)
   }
 
-  amount(amount: string | number | bigint): AddressBuilder {
+  amount(amount: TAmount): AddressBuilder {
     return ParaToRelayBuilder.create(this.api, this.from, amount)
   }
 
@@ -70,7 +78,7 @@ class GeneralBuilder {
     return new FromGeneralBuilder(this.api, node)
   }
 
-  to(node: TNode, paraIdTo?: number): AmountBuilder {
+  to(node: TDestination, paraIdTo?: number): AmountBuilder {
     return RelayToParaBuilder.create(this.api, node, paraIdTo)
   }
 }
@@ -91,9 +99,9 @@ export interface UseKeepAliveFinalBuilder {
 }
 
 export interface AddressBuilder {
-  address: (address: string) => UseKeepAliveFinalBuilder
+  address: (address: TAddress) => UseKeepAliveFinalBuilder
 }
 
 export interface AmountBuilder {
-  amount: (amount: string | number | bigint) => AddressBuilder
+  amount: (amount: TAmount) => AddressBuilder
 }

--- a/packages/sdk/src/builder/builders/OpenChannelBuilder.ts
+++ b/packages/sdk/src/builder/builders/OpenChannelBuilder.ts
@@ -5,7 +5,8 @@ import {
   type TSerializedApiCall,
   type Extrinsic,
   type TNode,
-  type TOpenChannelOptions
+  type TOpenChannelOptions,
+  type TDestination
 } from '../../types'
 import { openChannel, openChannelSerializedApiCall } from '../../pallets/parasSudoWrapper'
 import { type FinalBuilder } from './Builder'
@@ -23,18 +24,18 @@ class OpenChannelBuilder
 {
   private readonly api: ApiPromise
   private readonly from: TNode
-  private readonly to: TNode
+  private readonly to: TDestination
 
   private _maxSize: number
   private _maxMessageSize: number
 
-  private constructor(api: ApiPromise, from: TNode, to: TNode) {
+  private constructor(api: ApiPromise, from: TNode, to: TDestination) {
     this.api = api
     this.from = from
     this.to = to
   }
 
-  static create(api: ApiPromise, from: TNode, to: TNode): MaxSizeOpenChannelBuilder {
+  static create(api: ApiPromise, from: TNode, to: TDestination): MaxSizeOpenChannelBuilder {
     return new OpenChannelBuilder(api, from, to)
   }
 
@@ -49,6 +50,9 @@ class OpenChannelBuilder
   }
 
   private buildOptions(): TOpenChannelOptions {
+    if (typeof this.to === 'object') {
+      throw new Error('Channels do not support multi-location destinations')
+    }
     return {
       api: this.api,
       origin: this.from,

--- a/packages/sdk/src/builder/builders/ParaToParaBuilder.ts
+++ b/packages/sdk/src/builder/builders/ParaToParaBuilder.ts
@@ -2,25 +2,34 @@
 
 import { type ApiPromise } from '@polkadot/api'
 import { send, sendSerializedApiCall } from '../../pallets/xcmPallet'
-import { type TSerializedApiCall, type Extrinsic, type TNode, type TSendOptions } from '../../types'
+import {
+  type TSerializedApiCall,
+  type Extrinsic,
+  type TNode,
+  type TSendOptions,
+  type TCurrency,
+  type TAmount,
+  type TAddress,
+  type TDestination
+} from '../../types'
 import { type UseKeepAliveFinalBuilder, type AddressBuilder, type AmountBuilder } from './Builder'
 
 class ParaToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveFinalBuilder {
   private readonly api?: ApiPromise
   private readonly from: TNode
-  private readonly to: TNode
-  private readonly currency: string | number | bigint
+  private readonly to: TDestination
+  private readonly currency: TCurrency
   private readonly paraIdTo?: number
 
-  private _amount: string | number | bigint
-  private _address: string
+  private _amount: TAmount
+  private _address: TAddress
   private _destApi?: ApiPromise
 
   private constructor(
     api: ApiPromise | undefined,
     from: TNode,
-    to: TNode,
-    currency: string | number | bigint,
+    to: TDestination,
+    currency: TCurrency,
     paraIdTo?: number
   ) {
     this.api = api
@@ -33,19 +42,19 @@ class ParaToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveFi
   static createParaToPara(
     api: ApiPromise | undefined,
     from: TNode,
-    to: TNode,
-    currency: string | number | bigint,
+    to: TDestination,
+    currency: TCurrency,
     paraIdTo?: number
   ): AmountBuilder {
     return new ParaToParaBuilder(api, from, to, currency, paraIdTo)
   }
 
-  amount(amount: string | number | bigint): this {
+  amount(amount: TAmount): this {
     this._amount = amount
     return this
   }
 
-  address(address: string): this {
+  address(address: TAddress): this {
     this._address = address
     return this
   }

--- a/packages/sdk/src/builder/builders/ParaToRelayBuilder.ts
+++ b/packages/sdk/src/builder/builders/ParaToRelayBuilder.ts
@@ -2,33 +2,36 @@
 
 import { type ApiPromise } from '@polkadot/api'
 import { send, sendSerializedApiCall } from '../../pallets/xcmPallet'
-import { type TSerializedApiCall, type Extrinsic, type TNode, type TSendOptions } from '../../types'
+import {
+  type TSerializedApiCall,
+  type Extrinsic,
+  type TNode,
+  type TSendOptions,
+  type TAmount,
+  type TAddress
+} from '../../types'
 import { getRelayChainSymbol } from '../../pallets/assets'
 import { type UseKeepAliveFinalBuilder, type AddressBuilder } from './Builder'
 
 class ParaToRelayBuilder implements AddressBuilder, UseKeepAliveFinalBuilder {
   private readonly api?: ApiPromise
   private readonly from: TNode
-  private readonly amount: string | number | bigint
+  private readonly amount: TAmount
 
-  private _address: string
+  private _address: TAddress
   private _destApi?: ApiPromise
 
-  private constructor(api: ApiPromise | undefined, from: TNode, amount: string | number | bigint) {
+  private constructor(api: ApiPromise | undefined, from: TNode, amount: TAmount) {
     this.api = api
     this.from = from
     this.amount = amount
   }
 
-  static create(
-    api: ApiPromise | undefined,
-    from: TNode,
-    amount: string | number | bigint
-  ): AddressBuilder {
+  static create(api: ApiPromise | undefined, from: TNode, amount: TAmount): AddressBuilder {
     return new ParaToRelayBuilder(api, from, amount)
   }
 
-  address(address: string): this {
+  address(address: TAddress): this {
     this._address = address
     return this
   }

--- a/packages/sdk/src/builder/builders/RelayToParaBuilder.ts
+++ b/packages/sdk/src/builder/builders/RelayToParaBuilder.ts
@@ -5,27 +5,28 @@ import { transferRelayToPara, transferRelayToParaSerializedApiCall } from '../..
 import {
   type TSerializedApiCall,
   type Extrinsic,
-  type TNode,
-  type TRelayToParaOptions
+  type TRelayToParaOptions,
+  type TDestination,
+  type TAddress
 } from '../../types'
 import { type UseKeepAliveFinalBuilder, type AddressBuilder, type AmountBuilder } from './Builder'
 
 class RelayToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveFinalBuilder {
   private readonly api?: ApiPromise
-  private readonly to: TNode
+  private readonly to: TDestination
   private readonly paraIdTo?: number
 
   private _amount: number
-  private _address: string
+  private _address: TAddress
   private _destApi?: ApiPromise
 
-  private constructor(api: ApiPromise | undefined, to: TNode, paraIdTo?: number) {
+  private constructor(api: ApiPromise | undefined, to: TDestination, paraIdTo?: number) {
     this.api = api
     this.to = to
     this.paraIdTo = paraIdTo
   }
 
-  static create(api: ApiPromise | undefined, to: TNode, paraIdTo?: number): AmountBuilder {
+  static create(api: ApiPromise | undefined, to: TDestination, paraIdTo?: number): AmountBuilder {
     return new RelayToParaBuilder(api, to, paraIdTo)
   }
 
@@ -34,7 +35,7 @@ class RelayToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveF
     return this
   }
 
-  address(address: string): this {
+  address(address: TAddress): this {
     this._address = address
     return this
   }

--- a/packages/sdk/src/nodes/supported/AssetHubPolkadot.ts
+++ b/packages/sdk/src/nodes/supported/AssetHubPolkadot.ts
@@ -11,6 +11,7 @@ import {
   type TScenario,
   type TRelayToParaInternalOptions
 } from '../../types'
+import { type TMultiLocation } from '../../types/TMultiLocation'
 import ParachainNode from '../ParachainNode'
 import PolkadotXCMTransferImpl from '../PolkadotXCMTransferImpl'
 
@@ -40,7 +41,8 @@ class AssetHubPolkadot extends ParachainNode implements IPolkadotXCMTransfer {
     amount: string,
     scenario: TScenario,
     version: Version,
-    currencyId?: string
+    currencyId?: string,
+    overridedMultiLocation?: TMultiLocation
   ): any {
     if (scenario === 'ParaToPara') {
       const interior = {
@@ -53,7 +55,7 @@ class AssetHubPolkadot extends ParachainNode implements IPolkadotXCMTransfer {
           }
         ]
       }
-      return createCurrencySpec(amount, version, Parents.ZERO, interior)
+      return createCurrencySpec(amount, version, Parents.ZERO, overridedMultiLocation, interior)
     } else {
       return super.createCurrencySpec(amount, scenario, version, currencyId)
     }

--- a/packages/sdk/src/nodes/supported/Astar.ts
+++ b/packages/sdk/src/nodes/supported/Astar.ts
@@ -43,10 +43,15 @@ class Astar extends ParachainNode implements IPolkadotXCMTransfer, IXTokensTrans
       address,
       destination,
       paraIdTo,
+      overridedCurrencyMultiLocation,
       serializedApiCallEnabled = false
     } = options
     const scenario: TScenario = destination !== undefined ? 'ParaToPara' : 'ParaToRelay'
-    const paraId = destination !== undefined ? paraIdTo ?? getParaId(destination) : undefined
+    const paraId =
+      destination !== undefined && typeof destination !== 'object'
+        ? paraIdTo ?? getParaId(destination)
+        : undefined
+
     const node = this.node
     if (supportsXTokens(this) && currencySymbol !== 'ASTR') {
       return this.transferXTokens({
@@ -67,12 +72,13 @@ class Astar extends ParachainNode implements IPolkadotXCMTransfer, IXTokensTrans
         scenario,
         paraIdTo: paraId,
         destination,
+        overridedCurrencyMultiLocation,
         serializedApiCallEnabled
       })
     } else if (supportsPolkadotXCM(this)) {
       return this.transferPolkadotXCM({
         api,
-        header: this.createPolkadotXcmHeader(scenario, paraId),
+        header: this.createPolkadotXcmHeader(scenario, destination, paraId),
         addressSelection: generateAddressPayload(
           api,
           scenario,
@@ -81,7 +87,13 @@ class Astar extends ParachainNode implements IPolkadotXCMTransfer, IXTokensTrans
           this.version,
           paraId
         ),
-        currencySelection: this.createCurrencySpec(amount, scenario, this.version, currencyId),
+        currencySelection: this.createCurrencySpec(
+          amount,
+          scenario,
+          this.version,
+          currencyId,
+          overridedCurrencyMultiLocation
+        ),
         scenario,
         currencySymbol,
         serializedApiCallEnabled

--- a/packages/sdk/src/nodes/supported/Darwinia.ts
+++ b/packages/sdk/src/nodes/supported/Darwinia.ts
@@ -13,6 +13,7 @@ import ParachainNode from '../ParachainNode'
 import { NodeNotSupportedError } from '../../errors'
 import XTokensTransferImpl from '../XTokensTransferImpl'
 import { createCurrencySpec } from '../../pallets/xcmPallet/utils'
+import { type TMultiLocation } from '../../types/TMultiLocation'
 
 class Darwinia extends ParachainNode implements IXTokensTransfer {
   constructor() {
@@ -34,7 +35,8 @@ class Darwinia extends ParachainNode implements IXTokensTransfer {
     amount: string,
     scenario: TScenario,
     version: Version,
-    currencyId?: string
+    currencyId?: string,
+    overridedMultiLocation?: TMultiLocation
   ): any {
     if (scenario === 'ParaToPara') {
       const interior = {
@@ -42,7 +44,7 @@ class Darwinia extends ParachainNode implements IXTokensTransfer {
           PalletInstance: 5
         }
       }
-      return createCurrencySpec(amount, version, Parents.ZERO, interior)
+      return createCurrencySpec(amount, version, Parents.ZERO, overridedMultiLocation, interior)
     } else {
       return super.createCurrencySpec(amount, scenario, version, currencyId)
     }

--- a/packages/sdk/src/pallets/assets/assetsUtils.ts
+++ b/packages/sdk/src/pallets/assets/assetsUtils.ts
@@ -1,16 +1,22 @@
 // Contains function for getting Asset ID or Symbol used in XCM call creation
 
-import { type TNode } from '../../types'
+import { type TCurrency, type TNode } from '../../types'
 import { getAssetsObject } from './assets'
 
 export const getAssetBySymbolOrId = (
   node: TNode,
-  symbolOrId: string | number
+  currency: TCurrency
 ): { symbol?: string; assetId?: string } | null => {
+  if (typeof currency === 'object') {
+    return null
+  }
+
+  const currencyString = currency.toString()
+
   const { otherAssets, nativeAssets, relayChainAssetSymbol } = getAssetsObject(node)
 
   const asset = [...otherAssets, ...nativeAssets].find(
-    ({ symbol, assetId }) => symbol === symbolOrId || assetId === symbolOrId
+    ({ symbol, assetId }) => symbol === currencyString || assetId === currencyString
   )
 
   if (asset !== undefined) {
@@ -18,7 +24,7 @@ export const getAssetBySymbolOrId = (
     return { symbol, assetId }
   }
 
-  if (relayChainAssetSymbol === symbolOrId) return { symbol: relayChainAssetSymbol }
+  if (relayChainAssetSymbol === currencyString) return { symbol: relayChainAssetSymbol }
 
   return null
 }

--- a/packages/sdk/src/pallets/xcmPallet/utils.ts
+++ b/packages/sdk/src/pallets/xcmPallet/utils.ts
@@ -5,19 +5,26 @@ import {
   type PolkadotXCMHeader,
   type TScenario,
   type Extrinsic,
-  type TRelayToParaInternalOptions
+  type TRelayToParaInternalOptions,
+  type TDestination,
+  type TNode
 } from '../../types'
 import { generateAddressPayload } from '../../utils'
-import { getParaId } from '../assets'
+import { getParaId, getTNode } from '../assets'
+import { type TMultiLocation } from '../../types/TMultiLocation'
 
 export const constructRelayToParaParameters = (
   { api, destination, address, amount, paraIdTo }: TRelayToParaInternalOptions,
   version: Version,
   includeFee = false
 ): any[] => {
-  const paraId = paraIdTo ?? getParaId(destination)
+  const paraId =
+    destination !== undefined && typeof destination !== 'object'
+      ? paraIdTo ?? getParaId(destination)
+      : undefined
+
   const parameters = [
-    createPolkadotXcmHeader('RelayToPara', version, paraId),
+    createPolkadotXcmHeader('RelayToPara', version, destination, paraId),
     generateAddressPayload(api, 'RelayToPara', null, address, version, paraId),
     createCurrencySpec(amount, version, Parents.ZERO),
     0
@@ -32,12 +39,13 @@ export const createCurrencySpec = (
   amount: string,
   version: Version,
   parents: Parents,
+  overridedMultiLocation?: TMultiLocation,
   interior: any = 'Here'
 ): any => ({
   [version]: [
     {
       id: {
-        Concrete: {
+        Concrete: overridedMultiLocation ?? {
           parents,
           interior
         }
@@ -52,6 +60,7 @@ export const createCurrencySpec = (
 export const createPolkadotXcmHeader = (
   scenario: TScenario,
   version: Version,
+  destination?: TDestination,
   nodeId?: number
 ): PolkadotXCMHeader => {
   const parents = scenario === 'RelayToPara' ? Parents.ZERO : Parents.ONE
@@ -63,15 +72,50 @@ export const createPolkadotXcmHeader = (
             Parachain: nodeId
           }
         }
+  const isMultiLocationDestination = typeof destination === 'object'
   return {
-    [scenario === 'RelayToPara' ? Version.V3 : version]: {
-      parents,
-      interior
-    }
+    [scenario === 'RelayToPara' ? Version.V3 : version]: isMultiLocationDestination
+      ? destination
+      : {
+          parents,
+          interior
+        }
   }
 }
 
 export const calculateTransactionFee = async (tx: Extrinsic, address: string): Promise<BN> => {
   const { partialFee } = await tx.paymentInfo(address)
   return partialFee.toBn()
+}
+
+export const findParachainJunction = (multilocation: TMultiLocation): number | null => {
+  const { interior }: any = multilocation
+  for (const key in interior) {
+    const junctions = interior[key]
+    if (Array.isArray(junctions)) {
+      for (const junction of junctions) {
+        if ('Parachain' in junction) {
+          return Number(junction.Parachain)
+        }
+      }
+    } else if (junctions !== undefined && 'Parachain' in junctions) {
+      return Number(junctions.Parachain)
+    }
+  }
+  return null
+}
+
+export const resolveTNodeFromMultiLocation = (multiLocation: TMultiLocation): TNode => {
+  const parachainId = findParachainJunction(multiLocation)
+  if (parachainId === null) {
+    throw new Error('Parachain ID not found in destination multi location.')
+  }
+
+  const node = getTNode(parachainId)
+
+  if (node === null) {
+    throw new Error('Node with specified paraId not found in destination multi location.')
+  }
+
+  return node
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -7,6 +7,7 @@ import {
   type NODE_NAMES,
   type SUPPORTED_PALLETS
 } from './maps/consts'
+import { type TMultiLocation } from './types/TMultiLocation'
 
 export type UpdateFunction = (name: string, index: number) => string
 export type Extrinsic = SubmittableExtrinsic<'promise'>
@@ -57,8 +58,9 @@ export interface XTokensTransferInput {
   fees: number
   scenario: TScenario
   origin: TNode
-  destination?: TNode
+  destination?: TDestination
   paraIdTo?: number
+  overridedCurrencyMultiLocation?: TMultiLocation
   serializedApiCallEnabled?: boolean
 }
 
@@ -67,10 +69,11 @@ export interface XTransferTransferInput {
   currency: string | undefined
   currencyID: string | undefined
   amount: string
-  recipientAddress: string
+  recipientAddress: TAddress
   origin: TNode
   paraId?: number
-  destination?: TNode
+  destination?: TDestination
+  overridedCurrencyMultiLocation?: TMultiLocation
   serializedApiCallEnabled?: boolean
 }
 
@@ -93,10 +96,13 @@ export interface PolkadotXCMTransferInput {
 }
 
 export type TAmount = string | number | bigint
+export type TCurrency = string | number | bigint | TMultiLocation
+export type TAddress = string | TMultiLocation
+export type TDestination = TNode | TMultiLocation
 
 export interface TSendBaseOptions {
-  address: string
-  destination?: TNode
+  address: TAddress
+  destination?: TDestination
   paraIdTo?: number
   destApiForKeepAlive?: ApiPromise
 }
@@ -104,7 +110,7 @@ export interface TSendBaseOptions {
 export interface TSendOptions extends TSendBaseOptions {
   api?: ApiPromise
   origin: TNode
-  currency: string | number | bigint
+  currency: TCurrency
   amount: TAmount
 }
 
@@ -117,12 +123,13 @@ export interface TSendInternalOptions extends TSendBaseOptions {
   currencySymbol: string | undefined
   currencyId: string | undefined
   amount: string
+  overridedCurrencyMultiLocation?: TMultiLocation
   serializedApiCallEnabled?: boolean
 }
 
 interface TRelayToParaBaseOptions {
-  destination: TNode
-  address: string
+  destination: TDestination
+  address: TAddress
   paraIdTo?: number
   destApiForKeepAlive?: ApiPromise
 }

--- a/packages/sdk/src/types/TMultiLocation.ts
+++ b/packages/sdk/src/types/TMultiLocation.ts
@@ -1,0 +1,113 @@
+export type JunctionType =
+  | 'Parachain'
+  | 'AccountId32'
+  | 'AccountIndex64'
+  | 'AccountKey20'
+  | 'PalletInstance'
+  | 'GeneralIndex'
+  | 'GeneralKey'
+  | 'OnlyChild'
+  | 'Plurality'
+  | 'GlobalConsensus'
+
+type NetworkId = string | null
+type BodyId = string | null
+type BodyPart = string | null
+type StringOrNumber = string | number
+type HexString = string
+
+interface JunctionParachain {
+  Parachain: StringOrNumber
+}
+
+interface JunctionAccountId32 {
+  AccountId32: {
+    network: NetworkId
+    id: HexString
+  }
+}
+
+interface JunctionAccountIndex64 {
+  AccountIndex64: {
+    network: NetworkId
+    index: StringOrNumber
+  }
+}
+
+interface JunctionAccountKey20 {
+  AccountKey20: {
+    network: NetworkId
+    key: HexString
+  }
+}
+
+interface JunctionPalletInstance {
+  PalletInstance: StringOrNumber
+}
+
+interface JunctionGeneralIndex {
+  GeneralIndex: StringOrNumber
+}
+
+interface JunctionGeneralKey {
+  GeneralKey: {
+    length: StringOrNumber
+    data: HexString
+  }
+}
+
+interface JunctionOnlyChild {
+  OnlyChild: string
+}
+
+interface JunctionPlurality {
+  Plurality: {
+    id: BodyId
+    part: BodyPart
+  }
+}
+
+interface JunctionGlobalConsensus {
+  GlobalConsensus: NetworkId
+}
+
+type Junction =
+  | JunctionParachain
+  | JunctionAccountId32
+  | JunctionAccountIndex64
+  | JunctionAccountKey20
+  | JunctionPalletInstance
+  | JunctionGeneralIndex
+  | JunctionGeneralKey
+  | JunctionOnlyChild
+  | JunctionPlurality
+  | JunctionGlobalConsensus
+
+interface Junctions {
+  X1?: Junction
+  X2?: [Junction, Junction]
+  X3?: [Junction, Junction, Junction]
+  X4?: [Junction, Junction, Junction, Junction]
+  X5?: [Junction, Junction, Junction, Junction, Junction]
+  X6?: [Junction, Junction, Junction, Junction, Junction, Junction]
+  X7?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction]
+  X8?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction]
+  X9?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction]
+  X10?: [
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction,
+    Junction
+  ]
+}
+
+export interface TMultiLocation {
+  parents: StringOrNumber
+  interior: Junctions
+}

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -10,7 +10,8 @@ import {
   type TSerializedApiCall,
   Version,
   type Extrinsic,
-  type TNodeWithRelayChains
+  type TNodeWithRelayChains,
+  type TAddress
 } from './types'
 import { nodes } from './maps/consts'
 import type ParachainNode from './nodes/ParachainNode'
@@ -37,10 +38,15 @@ export const generateAddressPayload = (
   api: ApiPromise,
   scenario: TScenario,
   pallet: TPallet | null,
-  recipientAddress: string,
+  recipientAddress: TAddress,
   version: Version,
   nodeId: number | undefined
 ): any => {
+  const isMultiLocation = typeof recipientAddress === 'object'
+  if (isMultiLocation) {
+    return { [version]: recipientAddress }
+  }
+
   const isEthAddress = ethers.utils.isAddress(recipientAddress)
 
   if (scenario === 'ParaToRelay') {

--- a/packages/xcm-router/src/types.ts
+++ b/packages/xcm-router/src/types.ts
@@ -2,8 +2,6 @@ import { type TNodeWithRelayChains, type Extrinsic, type TNode } from '@paraspel
 import { type Signer } from '@polkadot/types/types';
 import { type EXCHANGE_NODES } from './consts/consts';
 
-export type TBigNumber = string | number | bigint;
-
 export type TExchangeNode = (typeof EXCHANGE_NODES)[number];
 
 export interface TSwapOptions {


### PR DESCRIPTION
This PR request adds a feature to allow integration of MultiLocation objects in the transfer process. Instead of passing currency, address and destination traditionally, you can pass a MultiLocation object instead which will override default behaviour. This brings flexibility and customization to our SDK.

The Builder methods to(), currency() and address() have been modified to accept a MultiLocation type.

The MultiLocation object has the following structure:

```typescript
export interface TMultiLocation {
  parents: StringOrNumber
  interior: Junctions
}
```

The interior has to have one of the following keys: `X1, X2, X3, X4, X5, X6, X7, X8`. The Junctions enum can represent zero to eight steps down the hierarchy.

When using X1 ,pass the object as the value: `X1: {}`, otherwise use array `X2: []`.

Then in the object or array we can specify the junction type. We can only choose as many junctions as the number after X says. Otherwise a TS error will be thrown. These are available junctions:

```typescript
interface JunctionParachain {
  Parachain: StringOrNumber
}

interface JunctionAccountId32 {
  AccountId32: {
    network: NetworkId
    id: HexString
  }
}

interface JunctionAccountIndex64 {
  AccountIndex64: {
    network: NetworkId
    index: StringOrNumber
  }
}

interface JunctionAccountKey20 {
  AccountKey20: {
    network: NetworkId
    key: HexString
  }
}

interface JunctionPalletInstance {
  PalletInstance: StringOrNumber
}

interface JunctionGeneralIndex {
  GeneralIndex: StringOrNumber
}

interface JunctionGeneralKey {
  GeneralKey: {
    length: StringOrNumber
    data: HexString
  }
}

interface JunctionOnlyChild {
  OnlyChild: string
}

interface JunctionPlurality {
  Plurality: {
    id: BodyId
    part: BodyPart
  }
}

interface JunctionGlobalConsensus {
  GlobalConsensus: NetworkId
}
```

An example of overriding address in ParaToPara call:

```ts
return Builder(api)
        .from(from)
        .to(to)
        .currency(currency)
        .amount(amount)
        .address({
          parents: 1,
          interior: {
            X2: [
              {
                Parachain: 200,
              },
              {
                GeneralIndex: 0,
              },
            ],
          },
        })
        .build();
```

We can do the same with `currency()` and `to()`(destination).

An example of overriding currency in ParaToPara call:

```ts
return Builder(api)
        .from(from)
        .to(to)
        .currency({
          parents: 1,
          interior: {
            X2: [
              { PalletInstance: '50' }, { GeneralIndex: currencyId }
            ],
          },
        })
        .amount(amount)
        .address(address)
        .build();
```

An example of overriding destination in ParaToPara call:

```ts
return Builder(api)
        .from(from)
        .to({
          parents: 1,
          interior: {
            X1: {
            Parachain: nodeId
          }
          },
        })
        .currency(currency)
        .amount(amount)
        .address(address)
        .build();
```

However when the origin Parachain uses `XTokens` or `XTransfer` pallet MultiLocation destinations are not supported. In this case you need to use the address multilocation for both destination and address. Here is an example of such MultiLocation:

```ts
{
    parents: 1,
    interior: {
        X2: [{
                Parachain: nodeId
            },
            {
                AccountId32: {
                    network: 'any',
                    id: createAccountId(api, recipientAddress)
                }
            }
        ]
    }
}
```

For PolkadotXCM you can use all 3 options separately.
