### PR TITLE
feat(xcm-analyser): support comma delimited numbers

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -73,11 +73,23 @@ describe('convert', () => {
     expect(result).toBe('./AccountId32(null, accountID)');
   });
 
-  it('convert multilocation to URL with currency and amout multilocation', () => {
+  it('convert multilocation to URL with currency and amount multilocation', () => {
     const multilocation: MultiLocation = {
       parents: '0',
       interior: {
         X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+      },
+    };
+
+    const result = convertMultilocationToUrl(multilocation);
+    expect(result).toBe('./PalletInstance(50)/GeneralIndex(1984)');
+  });
+
+  it('convert multilocation to URL with currency and amount multilocation with comma', () => {
+    const multilocation: MultiLocation = {
+      parents: '0',
+      interior: {
+        X2: [{ PalletInstance: '50' }, { GeneralIndex: '1,984' }],
       },
     };
 

--- a/packages/xcm-analyser/src/converter/convert.ts
+++ b/packages/xcm-analyser/src/converter/convert.ts
@@ -1,4 +1,9 @@
-import { MultiLocationSchema, type Junction, type JunctionType, type MultiLocation } from '../types';
+import {
+  MultiLocationSchema,
+  type Junction,
+  type JunctionType,
+  type MultiLocation,
+} from '../types';
 import { convertJunctionToReadable, findMultiLocationInObject } from '../utils/utils';
 
 export const convertMultilocationToUrlJson = (multiLocationJson: string): string => {
@@ -7,7 +12,7 @@ export const convertMultilocationToUrlJson = (multiLocationJson: string): string
 };
 
 export const convertMultilocationToUrl = (args: unknown): string => {
-  const { parents, interior } = MultiLocationSchema.parse(args)
+  const { parents, interior } = MultiLocationSchema.parse(args);
   const parentsNum = Number(parents);
 
   const entries = Object.entries(interior);

--- a/packages/xcm-analyser/src/converter/convert.ts
+++ b/packages/xcm-analyser/src/converter/convert.ts
@@ -1,4 +1,4 @@
-import { type Junction, type JunctionType, type MultiLocation } from '../types';
+import { MultiLocationSchema, type Junction, type JunctionType, type MultiLocation } from '../types';
 import { convertJunctionToReadable, findMultiLocationInObject } from '../utils/utils';
 
 export const convertMultilocationToUrlJson = (multiLocationJson: string): string => {
@@ -6,7 +6,8 @@ export const convertMultilocationToUrlJson = (multiLocationJson: string): string
   return convertMultilocationToUrl(multiLocation);
 };
 
-export const convertMultilocationToUrl = ({ parents, interior }: MultiLocation): string => {
+export const convertMultilocationToUrl = (args: unknown): string => {
+  const { parents, interior } = MultiLocationSchema.parse(args)
   const parentsNum = Number(parents);
 
   const entries = Object.entries(interior);
@@ -26,8 +27,8 @@ export const convertMultilocationToUrl = ({ parents, interior }: MultiLocation):
   return `${pathStart}${path}`;
 };
 
-export const convertXCMToUrls = (txArguments: any): string[] => {
-  return txArguments.flatMap((arg: any) => {
+export const convertXCMToUrls = (args: unknown[]): string[] => {
+  return args.flatMap((arg) => {
     const multiLocation = findMultiLocationInObject(arg);
     if (multiLocation !== null && multiLocation !== undefined) {
       return [convertMultilocationToUrl(multiLocation)];

--- a/packages/xcm-analyser/src/types.ts
+++ b/packages/xcm-analyser/src/types.ts
@@ -15,7 +15,12 @@ export type JunctionType =
 const NetworkId = z.string().nullable();
 const BodyId = z.string().nullable();
 const BodyPart = z.string().nullable();
-const StringOrNumber = z.string().regex(/^\d+$/).or(z.number()).or(z.bigint());
+const StringOrNumber = z
+  .string()
+  .regex(/^(?:\d{1,3}(?:,\d{3})*|\d+)$/)
+  .transform((s) => s.replace(/,/g, ''))
+  .or(z.number())
+  .or(z.bigint()); 
 const HexString = z.string();
 
 const JunctionParachain = z.object({ Parachain: StringOrNumber });

--- a/packages/xcm-analyser/src/types.ts
+++ b/packages/xcm-analyser/src/types.ts
@@ -20,7 +20,7 @@ const StringOrNumber = z
   .regex(/^(?:\d{1,3}(?:,\d{3})*|\d+)$/)
   .transform((s) => s.replace(/,/g, ''))
   .or(z.number())
-  .or(z.bigint()); 
+  .or(z.bigint());
 const HexString = z.string();
 
 const JunctionParachain = z.object({ Parachain: StringOrNumber });


### PR DESCRIPTION
Tried it in PJS extension and apparently some numbers have commas in them. This adds comma support as well as update the public interface a little bit.

For the regexp I just asked AI...

---

To match any positive integer that may include commas as thousands separators, you can use the following regular expression:

```
^(?:\d{1,3}(?:,\d{3})*|\d+)$
```

Here's a breakdown of the regexp:

- `^` asserts the start of the string.
- `(?:...)` is a non-capturing group that groups the pattern inside it.
- `\d{1,3}` matches 1 to 3 digits.
- `(?:,\d{3})*` matches zero or more occurrences of a comma followed by exactly three digits.
- `|` is the alternation operator, which allows matching either the pattern before it or after it.
- `\d+` matches one or more digits.
- `$` asserts the end of the string.

This regular expression will match strings like:

- "123"
- "1,234"
- "1,234,567"
- "1234567"

It ensures that the number is a positive integer and that commas, if present, are used correctly as thousands separators.

Note that this regexp assumes that the comma is used as the thousands separator. If you need to support different thousands separators or digit grouping formats, you may need to modify the regexp accordingly.