### PR TITLE
refactor(sdk): Add types for MultiLocations structures

### DIFF
--- a/packages/sdk/src/nodes/XTokensTransferImpl.ts
+++ b/packages/sdk/src/nodes/XTokensTransferImpl.ts
@@ -6,7 +6,8 @@ import {
   type TPallet,
   type TSerializedApiCall,
   type XTokensTransferInput,
-  Parents
+  Parents,
+  type TCurrencySelectionHeader
 } from '../types'
 import { getNode, lowercaseFirstLetter } from '../utils'
 
@@ -15,7 +16,7 @@ const getModifiedCurrencySelection = (
   amount: string,
   currencyId?: string,
   paraIdTo?: number
-): any => {
+): TCurrencySelectionHeader => {
   return {
     [version]: {
       id: {

--- a/packages/sdk/src/pallets/xcmPallet/utils.ts
+++ b/packages/sdk/src/pallets/xcmPallet/utils.ts
@@ -2,12 +2,13 @@ import { type BN } from '@polkadot/util'
 import {
   Version,
   Parents,
-  type PolkadotXCMHeader,
+  type TMultiLocationHeader,
   type TScenario,
   type Extrinsic,
   type TRelayToParaInternalOptions,
   type TDestination,
-  type TNode
+  type TNode,
+  type TCurrencySelectionHeaderArr
 } from '../../types'
 import { generateAddressPayload } from '../../utils'
 import { getParaId, getTNode } from '../assets'
@@ -23,7 +24,7 @@ export const constructRelayToParaParameters = (
       ? paraIdTo ?? getParaId(destination)
       : undefined
 
-  const parameters = [
+  const parameters: any[] = [
     createPolkadotXcmHeader('RelayToPara', version, destination, paraId),
     generateAddressPayload(api, 'RelayToPara', null, address, version, paraId),
     createCurrencySpec(amount, version, Parents.ZERO),
@@ -41,7 +42,7 @@ export const createCurrencySpec = (
   parents: Parents,
   overridedMultiLocation?: TMultiLocation,
   interior: any = 'Here'
-): any => ({
+): TCurrencySelectionHeaderArr => ({
   [version]: [
     {
       id: {
@@ -62,7 +63,7 @@ export const createPolkadotXcmHeader = (
   version: Version,
   destination?: TDestination,
   nodeId?: number
-): PolkadotXCMHeader => {
+): TMultiLocationHeader => {
   const parents = scenario === 'RelayToPara' ? Parents.ZERO : Parents.ONE
   const interior =
     scenario === 'ParaToRelay'

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -185,11 +185,25 @@ export enum Parents {
   ZERO = 0
 }
 
-export type PolkadotXCMHeader = {
-  [K in Version]?: {
-    parents: Parents
-    interior: any
+export type TMultiLocationHeader = {
+  [key in Version]?: TMultiLocation
+}
+
+export interface TCurrencySelection {
+  id: {
+    Concrete: TMultiLocation
   }
+  fun: {
+    Fungible: string
+  }
+}
+
+export type TCurrencySelectionHeader = {
+  [key in Version]?: TCurrencySelection
+}
+
+export type TCurrencySelectionHeaderArr = {
+  [key in Version]?: [TCurrencySelection]
 }
 
 export interface CheckKeepAliveOptions {

--- a/packages/sdk/src/types/TMultiLocation.ts
+++ b/packages/sdk/src/types/TMultiLocation.ts
@@ -17,12 +17,12 @@ type StringOrNumber = string | number
 type HexString = string
 
 interface JunctionParachain {
-  Parachain: StringOrNumber
+  Parachain: StringOrNumber | undefined
 }
 
 interface JunctionAccountId32 {
   AccountId32: {
-    network: NetworkId
+    network?: NetworkId
     id: HexString
   }
 }
@@ -36,7 +36,7 @@ interface JunctionAccountIndex64 {
 
 interface JunctionAccountKey20 {
   AccountKey20: {
-    network: NetworkId
+    network?: NetworkId
     key: HexString
   }
 }
@@ -71,7 +71,7 @@ interface JunctionGlobalConsensus {
   GlobalConsensus: NetworkId
 }
 
-type Junction =
+export type TJunction =
   | JunctionParachain
   | JunctionAccountId32
   | JunctionAccountIndex64
@@ -84,26 +84,36 @@ type Junction =
   | JunctionGlobalConsensus
 
 interface Junctions {
-  X1?: Junction
-  X2?: [Junction, Junction]
-  X3?: [Junction, Junction, Junction]
-  X4?: [Junction, Junction, Junction, Junction]
-  X5?: [Junction, Junction, Junction, Junction, Junction]
-  X6?: [Junction, Junction, Junction, Junction, Junction, Junction]
-  X7?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction]
-  X8?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction]
-  X9?: [Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction]
+  X1?: TJunction
+  X2?: [TJunction, TJunction]
+  X3?: [TJunction, TJunction, TJunction]
+  X4?: [TJunction, TJunction, TJunction, TJunction]
+  X5?: [TJunction, TJunction, TJunction, TJunction, TJunction]
+  X6?: [TJunction, TJunction, TJunction, TJunction, TJunction, TJunction]
+  X7?: [TJunction, TJunction, TJunction, TJunction, TJunction, TJunction, TJunction]
+  X8?: [TJunction, TJunction, TJunction, TJunction, TJunction, TJunction, TJunction, TJunction]
+  X9?: [
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction
+  ]
   X10?: [
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction,
-    Junction
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction,
+    TJunction
   ]
 }
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -11,7 +11,9 @@ import {
   Version,
   type Extrinsic,
   type TNodeWithRelayChains,
-  type TAddress
+  type TAddress,
+  type TMultiLocationHeader,
+  Parents
 } from './types'
 import { nodes } from './maps/consts'
 import type ParachainNode from './nodes/ParachainNode'
@@ -41,7 +43,7 @@ export const generateAddressPayload = (
   recipientAddress: TAddress,
   version: Version,
   nodeId: number | undefined
-): any => {
+): TMultiLocationHeader => {
   const isMultiLocation = typeof recipientAddress === 'object'
   if (isMultiLocation) {
     return { [version]: recipientAddress }
@@ -52,7 +54,7 @@ export const generateAddressPayload = (
   if (scenario === 'ParaToRelay') {
     return {
       [version]: {
-        parents: pallet === 'XTokens' ? 1 : 0,
+        parents: pallet === 'XTokens' ? Parents.ONE : Parents.ZERO,
         interior: {
           X1: {
             AccountId32: {
@@ -68,7 +70,7 @@ export const generateAddressPayload = (
   if (scenario === 'ParaToPara' && pallet === 'XTokens') {
     return {
       [version]: {
-        parents: 1,
+        parents: Parents.ONE,
         interior: {
           X2: [
             {
@@ -91,7 +93,7 @@ export const generateAddressPayload = (
   if (scenario === 'ParaToPara' && pallet === 'PolkadotXcm') {
     return {
       [version]: {
-        parents: 0,
+        parents: Parents.ZERO,
         interior: {
           X1: {
             [isEthAddress ? 'AccountKey20' : 'AccountId32']: {
@@ -107,16 +109,12 @@ export const generateAddressPayload = (
   }
 
   return {
-    V3: {
-      parents: 0,
+    [Version.V3]: {
+      parents: Parents.ZERO,
       interior: {
-        X1: {
-          [isEthAddress ? 'AccountKey20' : 'AccountId32']: {
-            ...(isEthAddress
-              ? { key: recipientAddress }
-              : { id: createAccID(api, recipientAddress) })
-          }
-        }
+        X1: isEthAddress
+          ? { AccountKey20: { key: recipientAddress } }
+          : { AccountId32: { id: createAccID(api, recipientAddress) } }
       }
     }
   }


### PR DESCRIPTION
Changes:
- Add types to all object structures within the ParaSpell SDK that correspond to MultiLocation format