### PR TITLE
feat(sdk): Add ability to override XCM version ✨

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,7 @@ NOTES:
 - When using a multilocation array the amount parameter is overridden.
 - Multilocation arrays are now available. Customize your asset multilocations by .currency([{multilocation1},{multilocation2}..{multilocationN}]) For more information refer to the official documentation or following PR https://github.com/paraspell/xcm-tools/pull/224.
 - POLKADOT <> KUSAMA Bridge is now available! Try sending DOT or KSM between AssetHubs.
+- You can now customize XCM Version! Try using .xcmVersion parameter after address in builder.
 ```
 
 ### Builder pattern:
@@ -78,6 +79,7 @@ await Builder(/*node api - optional*/)
       /*.feeAsset(feeAsset) - Parameter required when using MultilocationArray*/
       .amount(amount) // Overriden when using MultilocationArray
       .address(address | Multilocation object /*If you are sending through xTokens, you need to pass the destination and address multilocation in one object (x2)*/)
+      /*.xcmVersion(Version.V1/V2/V3/V4  //Optional parameter for manual override of XCM Version used in call*/
       .build()
 /*
 EXAMPLE:
@@ -96,6 +98,7 @@ await Builder(/*node api - optional*/)
       .to(NODE/*,customParaId - optional*/ | Multilocation object)
       .amount(amount)
       .address(address | Multilocation object)
+      /*.xcmVersion(Version.V1/V2/V3/V4  //Optional parameter for manual override of XCM Version used in call*/
       .build()
 /*
 EXAMPLE:
@@ -112,6 +115,7 @@ await Builder(/*node api - optional*/)
       .from(NODE)
       .amount(amount)
       .address(address | Multilocation object)
+      /*.xcmVersion(Version.V1/V2/V3/V4  //Optional parameter for manual override of XCM Version used in call*/
       .build()
 /*
 EXAMPLE:
@@ -132,6 +136,7 @@ await Builder(/*node api - optional*/)
       .amount(amount)
       .address(address)
       .useKeepAlive(destinationParaAPI)
+      /*.xcmVersion(Version.V1/V2/V3/V4  //Optional parameter for manual override of XCM Version used in call*/
       .build()
 ```
 ##### Close HRMP channels

--- a/packages/sdk/src/builder/builders/Builder.ts
+++ b/packages/sdk/src/builder/builders/Builder.ts
@@ -12,7 +12,8 @@ import {
   type TCurrency,
   type TMultiAsset,
   type TNodeWithRelayChains,
-  type TVersionClaimAssets
+  type TVersionClaimAssets,
+  type Version
 } from '../../types'
 import CloseChannelBuilder, { type InboundCloseChannelBuilder } from './CloseChannelBuilder'
 import OpenChannelBuilder, { type MaxSizeOpenChannelBuilder } from './OpenChannelBuilder'
@@ -115,6 +116,7 @@ export interface FinalBuilderAsync {
 
 export interface UseKeepAliveFinalBuilder {
   useKeepAlive: (destApi: ApiPromise) => UseKeepAliveFinalBuilder
+  xcmVersion: (version: Version) => UseKeepAliveFinalBuilder
   build: () => Promise<Extrinsic | never>
   buildSerializedApiCall: () => Promise<TSerializedApiCall>
 }

--- a/packages/sdk/src/builder/builders/ParaToParaBuilder.ts
+++ b/packages/sdk/src/builder/builders/ParaToParaBuilder.ts
@@ -11,7 +11,8 @@ import {
   type TAmount,
   type TAddress,
   type TDestination,
-  type TCurrency
+  type TCurrency,
+  type Version
 } from '../../types'
 import {
   type UseKeepAliveFinalBuilder,
@@ -33,6 +34,7 @@ class ParaToParaBuilder
   private _amount: TAmount | null
   private _address: TAddress
   private _destApi?: ApiPromise
+  private _version?: Version
 
   private constructor(
     api: ApiPromise | undefined,
@@ -78,6 +80,11 @@ class ParaToParaBuilder
     return this
   }
 
+  xcmVersion(version: Version): this {
+    this._version = version
+    return this
+  }
+
   private buildOptions(): TSendOptions {
     return {
       api: this.api,
@@ -88,7 +95,8 @@ class ParaToParaBuilder
       destination: this.to,
       paraIdTo: this.paraIdTo,
       feeAsset: this._feeAsset,
-      destApiForKeepAlive: this._destApi
+      destApiForKeepAlive: this._destApi,
+      version: this._version
     }
   }
 

--- a/packages/sdk/src/builder/builders/ParaToRelayBuilder.ts
+++ b/packages/sdk/src/builder/builders/ParaToRelayBuilder.ts
@@ -9,7 +9,8 @@ import {
   type TSendOptions,
   type TAmount,
   type TAddress,
-  type TCurrency
+  type TCurrency,
+  type Version
 } from '../../types'
 import { getRelayChainSymbol } from '../../pallets/assets'
 import { type UseKeepAliveFinalBuilder, type AddressBuilder } from './Builder'
@@ -22,6 +23,7 @@ class ParaToRelayBuilder implements AddressBuilder, UseKeepAliveFinalBuilder {
 
   private _address: TAddress
   private _destApi?: ApiPromise
+  private _version?: Version
 
   private constructor(
     api: ApiPromise | undefined,
@@ -54,6 +56,11 @@ class ParaToRelayBuilder implements AddressBuilder, UseKeepAliveFinalBuilder {
     return this
   }
 
+  xcmVersion(version: Version): this {
+    this._version = version
+    return this
+  }
+
   private buildOptions(): TSendOptions {
     if (this.amount === null) {
       throw new Error('Amount is required')
@@ -66,7 +73,8 @@ class ParaToRelayBuilder implements AddressBuilder, UseKeepAliveFinalBuilder {
       amount: this.amount,
       address: this._address,
       feeAsset: this.feeAsset,
-      destApiForKeepAlive: this._destApi
+      destApiForKeepAlive: this._destApi,
+      version: this._version
     }
   }
 

--- a/packages/sdk/src/builder/builders/RelayToParaBuilder.ts
+++ b/packages/sdk/src/builder/builders/RelayToParaBuilder.ts
@@ -7,7 +7,8 @@ import {
   type Extrinsic,
   type TRelayToParaOptions,
   type TDestination,
-  type TAddress
+  type TAddress,
+  type Version
 } from '../../types'
 import { type UseKeepAliveFinalBuilder, type AddressBuilder, type AmountBuilder } from './Builder'
 
@@ -19,6 +20,7 @@ class RelayToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveF
   private _amount: number
   private _address: TAddress
   private _destApi?: ApiPromise
+  private _version?: Version
 
   private constructor(api: ApiPromise | undefined, to: TDestination, paraIdTo?: number) {
     this.api = api
@@ -45,6 +47,11 @@ class RelayToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveF
     return this
   }
 
+  xcmVersion(version: Version): this {
+    this._version = version
+    return this
+  }
+
   private buildOptions(): TRelayToParaOptions {
     return {
       api: this.api,
@@ -52,7 +59,8 @@ class RelayToParaBuilder implements AmountBuilder, AddressBuilder, UseKeepAliveF
       amount: this._amount,
       address: this._address,
       paraIdTo: this.paraIdTo,
-      destApiForKeepAlive: this._destApi
+      destApiForKeepAlive: this._destApi,
+      version: this._version
     }
   }
 

--- a/packages/sdk/src/nodes/ParachainNode.ts
+++ b/packages/sdk/src/nodes/ParachainNode.ts
@@ -96,6 +96,7 @@ abstract class ParachainNode {
       paraIdTo,
       overridedCurrencyMultiLocation,
       feeAsset,
+      version = this.version,
       serializedApiCallEnabled = false
     } = options
     const scenario: TScenario = destination !== undefined ? 'ParaToPara' : 'ParaToRelay'
@@ -115,7 +116,7 @@ abstract class ParachainNode {
           scenario,
           'XTokens',
           address,
-          this.version,
+          version,
           paraId
         ),
         fees: getFees(scenario),
@@ -143,13 +144,13 @@ abstract class ParachainNode {
     } else if (supportsPolkadotXCM(this)) {
       return this.transferPolkadotXCM({
         api,
-        header: this.createPolkadotXcmHeader(scenario, destination, paraId),
+        header: this.createPolkadotXcmHeader(scenario, version, destination, paraId),
         addressSelection: generateAddressPayload(
           api,
           scenario,
           'PolkadotXcm',
           address,
-          this.version,
+          version,
           paraId
         ),
         address,
@@ -157,7 +158,7 @@ abstract class ParachainNode {
         currencySelection: this.createCurrencySpec(
           amount,
           scenario,
-          this.version,
+          version,
           currencyId,
           overridedCurrencyMultiLocation
         ),
@@ -176,10 +177,11 @@ abstract class ParachainNode {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'reserveTransferAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3)
+      parameters: constructRelayToParaParameters(options, version)
     }
   }
 
@@ -206,8 +208,13 @@ abstract class ParachainNode {
     )
   }
 
-  createPolkadotXcmHeader(scenario: TScenario, destination?: TDestination, paraId?: number): any {
-    return createPolkadotXcmHeader(scenario, this.version, destination, paraId)
+  createPolkadotXcmHeader(
+    scenario: TScenario,
+    version: Version,
+    destination?: TDestination,
+    paraId?: number
+  ): any {
+    return createPolkadotXcmHeader(scenario, version, destination, paraId)
   }
 }
 

--- a/packages/sdk/src/nodes/supported/AssetHubKusama.ts
+++ b/packages/sdk/src/nodes/supported/AssetHubKusama.ts
@@ -42,10 +42,11 @@ class AssetHubKusama extends ParachainNode implements IPolkadotXCMTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedTeleportAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 

--- a/packages/sdk/src/nodes/supported/AssetHubPolkadot.ts
+++ b/packages/sdk/src/nodes/supported/AssetHubPolkadot.ts
@@ -95,10 +95,11 @@ class AssetHubPolkadot extends ParachainNode implements IPolkadotXCMTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedTeleportAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 

--- a/packages/sdk/src/nodes/supported/Collectives.ts
+++ b/packages/sdk/src/nodes/supported/Collectives.ts
@@ -28,10 +28,11 @@ class Collectives extends ParachainNode implements IPolkadotXCMTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedTeleportAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 

--- a/packages/sdk/src/nodes/supported/CoretimeKusama.ts
+++ b/packages/sdk/src/nodes/supported/CoretimeKusama.ts
@@ -30,10 +30,11 @@ class CoretimeKusama extends ParachainNode implements IPolkadotXCMTransfer {
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
     // TESTED block hash on Rococo: 0x28929f7b2aeadbf3333f05d35bed18214a4b23dd270bd072f99e8a0131d22456
     // https://rococo.subscan.io/extrinsic/0x469eec7dccb22696b0c95cf4f5eec4b367ad3dc23243a346cc2aad3cc9522800
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedTeleportAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 }

--- a/packages/sdk/src/nodes/supported/Encointer.ts
+++ b/packages/sdk/src/nodes/supported/Encointer.ts
@@ -32,10 +32,11 @@ class Encointer extends ParachainNode implements IPolkadotXCMTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V1 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedTeleportAssets',
-      parameters: constructRelayToParaParameters(options, Version.V1, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 }

--- a/packages/sdk/src/nodes/supported/Moonbeam.ts
+++ b/packages/sdk/src/nodes/supported/Moonbeam.ts
@@ -25,10 +25,11 @@ class Moonbeam extends ParachainNode implements IXTokensTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedReserveTransferAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 

--- a/packages/sdk/src/nodes/supported/Moonriver.ts
+++ b/packages/sdk/src/nodes/supported/Moonriver.ts
@@ -24,10 +24,11 @@ class Moonriver extends ParachainNode implements IXTokensTransfer {
   }
 
   transferRelayToPara(options: TRelayToParaInternalOptions): TSerializedApiCall {
+    const { version = Version.V3 } = options
     return {
       module: 'xcmPallet',
       section: 'limitedReserveTransferAssets',
-      parameters: constructRelayToParaParameters(options, Version.V3, true)
+      parameters: constructRelayToParaParameters(options, version, true)
     }
   }
 }

--- a/packages/sdk/src/pallets/xcmPallet/transfer.ts
+++ b/packages/sdk/src/pallets/xcmPallet/transfer.ts
@@ -33,6 +33,7 @@ const sendCommon = async (options: TSendOptionsCommon): Promise<Extrinsic | TSer
     paraIdTo,
     destApiForKeepAlive,
     feeAsset,
+    version,
     serializedApiCallEnabled = false
   } = options
 
@@ -162,6 +163,7 @@ const sendCommon = async (options: TSendOptionsCommon): Promise<Extrinsic | TSer
     paraIdTo,
     overridedCurrencyMultiLocation: isTMulti(currency) ? currency : undefined,
     feeAsset,
+    version,
     serializedApiCallEnabled
   })
 }
@@ -187,6 +189,7 @@ export const transferRelayToParaCommon = async (
     address,
     paraIdTo,
     destApiForKeepAlive,
+    version,
     serializedApiCallEnabled = false
   } = options
   const isMultiLocationDestination = typeof destination === 'object'
@@ -224,7 +227,8 @@ export const transferRelayToParaCommon = async (
     address,
     amount: amountStr,
     paraIdTo,
-    destApiForKeepAlive
+    destApiForKeepAlive,
+    version
   })
 
   if (serializedApiCallEnabled) {

--- a/packages/sdk/src/pallets/xcmPallet/utils.ts
+++ b/packages/sdk/src/pallets/xcmPallet/utils.ts
@@ -10,7 +10,7 @@ import {
   type TNode,
   type TCurrencySelectionHeaderArr
 } from '../../types'
-import { generateAddressPayload } from '../../utils'
+import { createX1Payload, generateAddressPayload } from '../../utils'
 import { getParaId, getTNode } from '../assets'
 import { type TMultiLocation } from '../../types/TMultiLocation'
 import { type TMultiAsset } from '../../types/TMultiAsset'
@@ -78,7 +78,7 @@ export const createCurrencySpec = (
     return {
       [version]: [
         {
-          id: { Concrete: { parents, interior } },
+          id: version === Version.V4 ? { parents, interior } : { Concrete: { parents, interior } },
           fun: { Fungible: amount }
         }
       ]
@@ -89,7 +89,7 @@ export const createCurrencySpec = (
     ? {
         [version]: [
           {
-            id: { Concrete: overriddenCurrency },
+            id: version === Version.V4 ? overriddenCurrency : { Concrete: overriddenCurrency },
             fun: { Fungible: amount }
           }
         ]
@@ -110,14 +110,13 @@ export const createPolkadotXcmHeader = (
   const interior =
     scenario === 'ParaToRelay'
       ? 'Here'
-      : {
-          X1: {
-            Parachain: nodeId
-          }
-        }
+      : createX1Payload(version, {
+          Parachain: nodeId
+        })
+
   const isMultiLocationDestination = typeof destination === 'object'
   return {
-    [scenario === 'RelayToPara' ? Version.V3 : version]: isMultiLocationDestination
+    [version]: isMultiLocationDestination
       ? destination
       : {
           parents,

--- a/packages/sdk/src/types/TMultiLocation.ts
+++ b/packages/sdk/src/types/TMultiLocation.ts
@@ -85,9 +85,9 @@ export type TJunction =
   | JunctionPlurality
   | JunctionGlobalConsensus
 
-interface Junctions {
+export interface Junctions {
   Here?: null
-  X1?: TJunction
+  X1?: TJunction | [TJunction]
   X2?: [TJunction, TJunction]
   X3?: [TJunction, TJunction, TJunction]
   X4?: [TJunction, TJunction, TJunction, TJunction]

--- a/packages/sdk/src/types/TTransfer.ts
+++ b/packages/sdk/src/types/TTransfer.ts
@@ -93,6 +93,7 @@ export interface TSendBaseOptions {
   paraIdTo?: number
   feeAsset?: TCurrency
   destApiForKeepAlive?: ApiPromise
+  version?: Version
 }
 
 export interface TSendOptions extends TSendBaseOptions {
@@ -120,6 +121,7 @@ interface TRelayToParaBaseOptions {
   address: TAddress
   paraIdTo?: number
   destApiForKeepAlive?: ApiPromise
+  version?: Version
 }
 
 export interface TRelayToParaOptions extends TRelayToParaBaseOptions {


### PR DESCRIPTION
Available versions to override:

```ts
export enum Version {
  V1 = 'V1',
  V2 = 'V2',
  V3 = 'V3',
  V4 = 'V4'
}
```

### Usage

Supported transfer scenarios: ParaToPara, ParaToRelay, RelayToPara
```ts
import { Version } from "@paraspell/sdk"

await Builder(api)
      .from(NODE)
      .to(NODE_2, PARA_ID_TO)
      .currency(CURRENCY)
      .amount(AMOUNT)
      .address(ADDRESS)
      .xcmVersion(Version.V2)
      .build()
```
      
### Usage with keep alive

```ts
await Builder(api)
     .from(NODE)
     .to(NODE_2, PARA_ID_TO)
     .currency(CURRENCY)
     .amount(AMOUNT)
     .address(ADDRESS)
     .useKeepAlive(destApi)
     .xcmVersion(Version.V2)
     .build()
```


_NOTE: optional property .xcmVersion() needs to be specified before build() and after address()._