### PR TITLE
feat(sdk): Add support for batch utility to Builder ✨

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -141,6 +141,30 @@ await Builder(/*node api - optional*/)
       /*.xcmVersion(Version.V1/V2/V3/V4)  //Optional parameter for manual override of XCM Version used in call*/
       .build()
 ```
+
+##### Batch calls
+You can batch XCM calls and execute multiple XCM calls within one call. All three scenarios (Para->Para, Para->Relay, Relay->Para) can be used and combined.
+```js
+await Builder(/*node api - optional*/)
+      .from(NODE) //Ensure, that origin node is the same in all batched XCM Calls.
+      .to(NODE_2) //Any compatible Parachain
+      .currency(currency) //Currency to transfer (If Para->Para), otherwise you do not need to specify .currency()
+      .amount(amount) 
+      .address(address | Multilocation object)
+      .addToBatch()
+
+      .from(NODE) //Ensure, that origin node is the same in all batched XCM Calls.
+      .to(NODE_3) //Any compatible Parachain
+      .currency(currency) //Currency to transfer (If Para->Para), otherwise you do not need to specify .currency()
+      .amount(amount)
+      .address(address | Multilocation object)
+      .addToBatch()
+      .buildBatch({ 
+          // This settings object is optional and batch all is the default option
+          mode: BatchMode.BATCH_ALL //or BatchMode.BATCH
+      })
+```
+
 ##### Close HRMP channels
 ```ts
 Builder(api)

--- a/packages/sdk/src/builder/builders/BatchTransactionManager.test.ts
+++ b/packages/sdk/src/builder/builders/BatchTransactionManager.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ApiPromise } from '@polkadot/api'
+import BatchTransactionManager from './BatchTransactionManager'
+import { BatchMode, TSendOptions } from '../../types'
+
+const mockSendTransaction = vi.fn()
+const batchMock = vi.fn()
+const batchAllMock = vi.fn()
+
+const mockApiPromise = {
+  tx: {
+    utility: {
+      batch: batchMock,
+      batchAll: batchAllMock
+    }
+  }
+} as unknown as ApiPromise
+
+describe('BatchTransactionManager', () => {
+  beforeEach(() => {
+    mockSendTransaction.mockClear()
+    batchMock.mockClear()
+    batchAllMock.mockClear()
+  })
+
+  describe('addTransaction', () => {
+    it('adds a transaction to the manager', () => {
+      const manager = new BatchTransactionManager()
+      expect(manager.isEmpty()).toBe(true)
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      expect(manager.isEmpty()).toBe(false)
+    })
+  })
+
+  describe('isEmpty', () => {
+    it('returns true when no transactions have been added', () => {
+      const manager = new BatchTransactionManager()
+      expect(manager.isEmpty()).toBe(true)
+    })
+
+    it('returns false when transactions are present', () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      expect(manager.isEmpty()).toBe(false)
+    })
+  })
+
+  describe('buildBatch', () => {
+    it('throws an error if there are no transactions', async () => {
+      const manager = new BatchTransactionManager()
+      await expect(
+        manager.buildBatch(mockApiPromise, 'Acala', undefined, { mode: BatchMode.BATCH_ALL })
+      ).rejects.toThrow('No transactions to batch.')
+    })
+
+    it('calls sendTransaction for each added transaction and batches them with batchAll', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await manager.buildBatch(mockApiPromise, 'Acala', undefined, { mode: BatchMode.BATCH_ALL })
+
+      expect(mockSendTransaction).toHaveBeenCalledTimes(2)
+      expect(batchAllMock).toHaveBeenCalled()
+    })
+
+    it('uses batch when BATCH mode is selected', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await manager.buildBatch(mockApiPromise, 'Acala', undefined, { mode: BatchMode.BATCH })
+
+      expect(batchMock).toHaveBeenCalled()
+    })
+
+    it('uses batchAll when BATCH_ALL mode is selected', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await manager.buildBatch(mockApiPromise, 'Acala', undefined, { mode: BatchMode.BATCH_ALL })
+
+      expect(batchAllMock).toHaveBeenCalled()
+    })
+
+    it('should fail if different origins are used', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Karura' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await expect(
+        manager.buildBatch(mockApiPromise, 'Acala', undefined, { mode: BatchMode.BATCH_ALL })
+      ).rejects.toThrow('All transactions must have the same origin.')
+    })
+
+    it('should fail if no from or to node is provided', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await expect(manager.buildBatch(mockApiPromise, undefined, undefined)).rejects.toThrow(
+        'From or to node is required'
+      )
+    })
+
+    it('should fail if to is an object', async () => {
+      const manager = new BatchTransactionManager()
+      manager.addTransaction({
+        func: mockSendTransaction,
+        options: { origin: 'Acala' } as TSendOptions
+      })
+      mockSendTransaction.mockResolvedValue({ hash: 'hash' })
+
+      await expect(
+        manager.buildBatch(mockApiPromise, 'Acala', { parents: 1, interior: 'Here' })
+      ).rejects.toThrow('Please provide ApiPromise instance.')
+    })
+  })
+})

--- a/packages/sdk/src/builder/builders/BatchTransactionManager.ts
+++ b/packages/sdk/src/builder/builders/BatchTransactionManager.ts
@@ -1,0 +1,73 @@
+import { ApiPromise } from '@polkadot/api'
+import {
+  BatchMode,
+  type TRelayToParaOptions,
+  type TSendOptions,
+  type Extrinsic,
+  type TBatchOptions,
+  TNode,
+  TDestination
+} from '../../types'
+import { createApiInstanceForNode, determineRelayChain } from '../../utils'
+
+type TOptions = TSendOptions | TRelayToParaOptions
+
+type TTransaction = {
+  func: (options: TOptions) => Promise<Extrinsic>
+  options: TOptions
+}
+
+class BatchTransactionManager {
+  private transactions: TTransaction[] = []
+
+  addTransaction(transaction: TTransaction) {
+    this.transactions.push(transaction)
+  }
+
+  isEmpty() {
+    return this.transactions.length === 0
+  }
+
+  async buildBatch(
+    api: ApiPromise | undefined,
+    from: TNode | undefined,
+    to: TDestination | undefined,
+    options: TBatchOptions = { mode: BatchMode.BATCH_ALL }
+  ): Promise<Extrinsic> {
+    if (!from && !to) {
+      throw new Error('From or to node is required')
+    }
+    if (to && typeof to === 'object') {
+      throw new Error('Please provide ApiPromise instance.')
+    }
+    const apiWithFallback =
+      api ?? (await createApiInstanceForNode(from ?? determineRelayChain(to as TNode)))
+
+    const { mode } = options
+    if (this.transactions.length === 0) {
+      throw new Error('No transactions to batch.')
+    }
+
+    const sameFrom = this.transactions.every(tx => {
+      if ('origin' in tx.options) {
+        return tx.options.origin === from
+      }
+      return true
+    })
+
+    if (!sameFrom) {
+      throw new Error('All transactions must have the same origin.')
+    }
+
+    const results = this.transactions.map(options => {
+      const { func, options: txOptions } = options
+      return func(txOptions)
+    })
+    const txs = await Promise.all(results)
+    return mode === BatchMode.BATCH_ALL
+      ? apiWithFallback.tx.utility.batchAll(txs)
+      : apiWithFallback.tx.utility.batch(txs)
+  }
+}
+
+export default BatchTransactionManager

--- a/packages/sdk/src/builder/builders/IBatchBuilder.ts
+++ b/packages/sdk/src/builder/builders/IBatchBuilder.ts
@@ -1,0 +1,10 @@
+import type { Extrinsic, TBatchOptions } from '../../types'
+import { GeneralBuilder } from './Builder'
+
+export interface IAddToBatchBuilder {
+  addToBatch(): GeneralBuilder
+}
+
+export interface IBuildBatchBuilder {
+  buildBatch(options?: TBatchOptions): Promise<Extrinsic>
+}

--- a/packages/sdk/src/types/TBuilder.ts
+++ b/packages/sdk/src/types/TBuilder.ts
@@ -1,5 +1,5 @@
-import { Signer } from 'ethers'
-import { TNodePolkadotKusama } from './TNode'
+import type { Signer } from 'ethers'
+import type { TNodePolkadotKusama } from './TNode'
 
 export type TEvmBuilderOptions = {
   to: TNodePolkadotKusama
@@ -25,3 +25,12 @@ type OptionalProperties<T> = {
 }
 
 export type TOptionalEvmBuilderOptions = OptionalProperties<TEvmBuilderOptions>
+
+export enum BatchMode {
+  BATCH_ALL = 'BATCH_ALL',
+  BATCH = 'BATCH'
+}
+
+export type TBatchOptions = {
+  mode: BatchMode
+}


### PR DESCRIPTION
Example:

```ts   
await Builder(api)
      .from(NODE)
      .to(NODE_2)
      .currency(CURRENCY)
      .amount(AMOUNT)
      .address(ADDRESS)
      .addToBatch()

      .from(NODE)
      .to(NODE_2)
      .currency(CURRENCY)
      .amount(AMOUNT)
      .address(ADDRESS)
      .addToBatch()
      .buildBatch({ 
          // This settings object is optional and batch all is the default option
          mode: BatchMode.BATCH_ALL
      })
```

addToBatch() -> Adds transaction to batch
buildBatch() -> Batches all extrinsics into one and returns it. It accepts settings object that can specify whether to use batchAll function or batch function:

Differences:
- `utility.batchAll()` - does not commit if one of the calls in the batch fails.
- `utility.batch()` - commits each successful call regardless if a call fails.

This feature works only when origin node is the same in all batched transactions. If this is not the case an error is thrown.
The code is flexible enough to be used in any other builder if we want to.