### PR TITLE
feat(xcm-api): Add balance queries to XCM-API 👨‍🔧

### DIFF
--- a/apps/playground/src/components/assets/AssetsQueries.tsx
+++ b/apps/playground/src/components/assets/AssetsQueries.tsx
@@ -83,32 +83,46 @@ const AssetsQueries = () => {
   const getEndpoint = ({ func, node }: FormValues) => {
     switch (func) {
       case "ASSETS_OBJECT":
-        return `${node}`;
+        return `/assets/${node}`;
       case "ASSET_ID":
-        return `${node}/id`;
+        return `/assets/${node}/id`;
       case "RELAYCHAIN_SYMBOL":
-        return `${node}/relay-chain-symbol`;
+        return `/assets/${node}/relay-chain-symbol`;
       case "NATIVE_ASSETS":
-        return `${node}/native`;
+        return `/assets/${node}/native`;
       case "OTHER_ASSETS":
-        return `${node}/other`;
+        return `/assets/${node}/other`;
       case "ALL_SYMBOLS":
-        return `${node}/all-symbols`;
+        return `/assets/${node}/all-symbols`;
       case "DECIMALS":
-        return `${node}/decimals`;
+        return `/assets/${node}/decimals`;
       case "HAS_SUPPORT":
-        return `${node}/has-support`;
+        return `/assets/${node}/has-support`;
       case "PARA_ID":
-        return `${node}/para-id`;
+        return `/assets/${node}/para-id`;
+      case "BALANCE_NATIVE":
+        return `/balance/${node}/native`;
+      case "BALANCE_FOREIGN":
+        return `/balance/${node}/foreign`;
     }
   };
 
   const getQueryResult = async (formValues: FormValues): Promise<unknown> => {
-    const { useApi } = formValues;
+    const { useApi, func, address, currencyType, currency } = formValues;
+    const isBalanceQuery =
+      func === "BALANCE_FOREIGN" || func === "BALANCE_NATIVE";
     if (useApi) {
       return await fetchFromApi(
-        formValues,
-        `/assets/${getEndpoint(formValues)}`,
+        isBalanceQuery
+          ? {
+              address,
+              currency:
+                currencyType === "id" ? { id: currency } : { symbol: currency },
+            }
+          : formValues,
+        `${getEndpoint(formValues)}`,
+        isBalanceQuery ? "POST" : "GET",
+        isBalanceQuery,
       );
     } else {
       return await submitUsingSdk(formValues);

--- a/apps/xcm-api/README.md
+++ b/apps/xcm-api/README.md
@@ -123,6 +123,25 @@ const response = await fetch('http://localhost:3001/x-transfer-hash', {
 });
 ```
 
+### Batch call
+
+A complete guide on asset claim can be found in [official docs](https://paraspell.github.io/docs/api/xcmP.html#batch-call).
+
+Possible parameters:
+     - `transfers` (Inside JSON body): (required): Represents array of XCM calls along with optional parameter "options" which contains "mode" to switch between BATCH and BATCH_ALL call forms.
+
+```js
+const response = await fetch("http://localhost:3001/x-transfer-batch", {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+        transfers: "Parachain", // Replace "transfers" with array of XCM transfers
+    })
+});
+```
+
 ### Asset claim
 
 A complete guide on asset claim can be found in [official docs](https://paraspell.github.io/docs/api/xcmP.html#asset-claim).
@@ -297,6 +316,29 @@ const response = await fetch('http://localhost:3001/assets/:paraID');
 
 //Retrieve a list of implemented Parachains
 const response = await fetch('http://localhost:3001/assets');
+
+//Query native asset balance
+const response = await fetch("http://localhost:3001/balance/:node/native", {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+        address: "Address" // Replace "Address" with wallet address (In AccountID32 or AccountKey20 Format) 
+    })
+});
+
+//Query foreign asset balance
+const response = await fetch("http://localhost:3001/balance/:node/foreign", {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+        address: "Address" // Replace "Address" with wallet address (In AccountID32 or AccountKey20 Format) 
+        currency: "Currency" //Replace "Currency" with either symbol { symbol: "KSM" } or  id { id: 123 }
+    })
+});
 ```
 
 ### XCM Pallet

--- a/apps/xcm-api/src/analytics/EventName.ts
+++ b/apps/xcm-api/src/analytics/EventName.ts
@@ -12,6 +12,8 @@ export enum EventName {
   GET_PARA_ID = 'Get Para Id',
   GET_DEFAULT_PALLET = 'Get Default Pallet',
   GET_SUPPORTED_PALLETS = 'Get Supported Pallets',
+  GET_BALANCE_NATIVE = 'Get Balance Native',
+  GET_BALANCE_FOREIGN = 'Get Balance Foreign',
   GENERATE_XCM_CALL = 'Generate XCM Call',
   GENERATE_XCM_CALL_HASH = 'Generate XCM Call Hash',
   GENERATE_XCM_CALL_BATCH_HASH = 'Generate XCM Call Batch Hash',

--- a/apps/xcm-api/src/app.module.ts
+++ b/apps/xcm-api/src/app.module.ts
@@ -23,6 +23,7 @@ import { AssetClaimModule } from './asset-claim/asset-claim.module.js';
 import { TransferInfoModule } from './transfer-info/transfer-info.module.js';
 import { XcmAnalyserModule } from './xcm-analyser/xcm-analyser.module.js';
 import { XTransferEthModule } from './x-transfer-eth/x-transfer-eth.module.js';
+import { BalanceModule } from './balance/balance.module.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,6 +39,7 @@ const __dirname = path.dirname(__filename);
     RouterModule,
     AssetsModule,
     PalletsModule,
+    BalanceModule,
     AuthModule,
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRootAsync({

--- a/apps/xcm-api/src/asset-claim/asset-claim.controller.test.ts
+++ b/apps/xcm-api/src/asset-claim/asset-claim.controller.test.ts
@@ -12,6 +12,19 @@ describe('AssetClaimController', () => {
   let assetClaimService: AssetClaimService;
   let analyticsService: AnalyticsService;
 
+  const bodyParams = {
+    from: 'address1',
+    fungible: [
+      {
+        id: { parents: 1, interior: { X1: { Parachain: 2000 } } },
+        fun: {
+          Fungible: '100',
+        },
+      },
+    ],
+    address: 'address2',
+  } as AssetClaimDto;
+
   beforeEach(() => {
     assetClaimService = {
       claimAssets: vi.fn(),
@@ -26,11 +39,6 @@ describe('AssetClaimController', () => {
 
   describe('claimAssets', () => {
     it('should call trackAnalytics and claimAssets with correct parameters', async () => {
-      const bodyParams = {
-        from: 'address1',
-        fungible: [{ id: 'asset1', fun: 100 }],
-      } as AssetClaimDto;
-
       const req = {
         headers: {
           'user-agent': 'Mozilla/5.0',
@@ -59,10 +67,6 @@ describe('AssetClaimController', () => {
 
   describe('claimAssetsHash', () => {
     it('should call trackAnalytics and claimAssets with hashEnabled set to true', async () => {
-      const bodyParams: AssetClaimDto = {
-        from: 'address1',
-        fungible: [{ id: 'asset1', fun: 100 }],
-      } as AssetClaimDto;
       const req = {
         headers: {
           'user-agent': 'Mozilla/5.0',

--- a/apps/xcm-api/src/asset-claim/asset-claim.controller.ts
+++ b/apps/xcm-api/src/asset-claim/asset-claim.controller.ts
@@ -19,7 +19,7 @@ export class AssetClaimController {
   ) {
     const { from, fungible } = params;
     this.analyticsService.track(eventName, req, {
-      from,
+      from: from || 'unknown',
       assetLength: fungible.length,
     });
   }

--- a/apps/xcm-api/src/asset-claim/asset-claim.service.ts
+++ b/apps/xcm-api/src/asset-claim/asset-claim.service.ts
@@ -9,7 +9,6 @@ import {
   NODES_WITH_RELAY_CHAINS,
   TMultiAsset,
   TNode,
-  TTransferReturn,
   createApiInstanceForNode,
 } from '@paraspell/sdk';
 import { isValidWalletAddress } from '../utils.js';
@@ -39,13 +38,12 @@ export class AssetClaimService {
 
     const api = await createApiInstanceForNode(fromNode);
 
-    let response: TTransferReturn;
     try {
       const builder = Builder(api)
         .claimFrom(fromNode)
         .fungible(fungible as TMultiAsset[])
         .account(address);
-      response = hashEnabled
+      return hashEnabled
         ? await builder.build()
         : await builder.buildSerializedApiCall();
     } catch (e) {
@@ -58,6 +56,5 @@ export class AssetClaimService {
     } finally {
       if (api) await api.disconnect();
     }
-    return response;
   }
 }

--- a/apps/xcm-api/src/auth/auth.guard.ts
+++ b/apps/xcm-api/src/auth/auth.guard.ts
@@ -29,6 +29,7 @@ export class AuthGuard implements CanActivate {
       const { userId } = this.jwtService.verify<{ userId: string }>(apiKey);
       if (!userId) throw new ForbiddenException('Invalid API key.');
       const dbUser = await this.usersService.findOne(userId);
+      if (!dbUser) throw new ForbiddenException('User not found.');
       this.analyticsService.identify(userId, {
         hasApiKey: 'true',
         requestLimit: dbUser.requestLimit,

--- a/apps/xcm-api/src/auth/auth.service.test.ts
+++ b/apps/xcm-api/src/auth/auth.service.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { AuthService } from './auth.service.js';
+import type { JwtService } from '@nestjs/jwt';
+import type { UsersService } from '../users/users.service.js';
+import type { ConfigService } from '@nestjs/config';
+import type { HigherRequestLimitDto } from './dto/HigherRequestLimitDto.js';
+import { sendEmail } from './utils/utils.js';
+import { validateRecaptcha } from '../utils/validateRecaptcha.js';
+
+vi.mock('./utils/utils.js', () => ({
+  sendEmail: vi.fn(),
+}));
+
+vi.mock('../utils/validateRecaptcha.js', () => ({
+  validateRecaptcha: vi.fn(),
+}));
+
+describe('AuthService', () => {
+  let authService: AuthService;
+  let jwtService: JwtService;
+  let usersService: UsersService;
+  let configService: ConfigService;
+
+  beforeEach(() => {
+    jwtService = {
+      signAsync: vi.fn(),
+      verify: vi.fn(),
+    } as unknown as JwtService;
+
+    usersService = {
+      create: vi.fn(),
+    } as unknown as UsersService;
+
+    configService = {
+      get: vi.fn(),
+    } as unknown as ConfigService;
+
+    authService = new AuthService(jwtService, usersService, configService);
+  });
+
+  describe('generateApiKey', () => {
+    it('should throw ForbiddenException if recaptcha secret key is not set', async () => {
+      vi.spyOn(configService, 'get').mockReturnValue(undefined);
+
+      await expect(
+        authService.generateApiKey('test-recaptcha'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException if recaptcha verification fails', async () => {
+      vi.spyOn(configService, 'get').mockReturnValue('secret-key');
+      vi.mocked(validateRecaptcha).mockResolvedValue(false);
+
+      await expect(
+        authService.generateApiKey('test-recaptcha'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return an api key if recaptcha verification passes', async () => {
+      const mockApiKey = 'test-api-key';
+      const mockUser = { id: 'user123', requestLimit: 1000 };
+
+      vi.spyOn(configService, 'get').mockReturnValue('secret-key');
+      vi.mocked(validateRecaptcha).mockResolvedValue(true);
+      const usersServiceSpy = vi
+        .spyOn(usersService, 'create')
+        .mockResolvedValue(mockUser);
+      const jwtServiceSpy = vi
+        .spyOn(jwtService, 'signAsync')
+        .mockResolvedValue(mockApiKey);
+
+      const result = await authService.generateApiKey('test-recaptcha');
+
+      expect(usersServiceSpy).toHaveBeenCalled();
+      expect(jwtServiceSpy).toHaveBeenCalledWith({
+        userId: mockUser.id,
+      });
+      expect(result).toEqual({ api_key: mockApiKey });
+    });
+  });
+
+  describe('submitHigherRequestLimitForm', () => {
+    it('should throw ForbiddenException if recaptcha secret key is not set', async () => {
+      vi.spyOn(configService, 'get').mockReturnValue(undefined);
+
+      const dto: HigherRequestLimitDto = {
+        email: 'test@example.com',
+        reason: 'Need more requests',
+        requestedLimit: '1000',
+        api_key: 'valid-api-key',
+        'g-recaptcha-response': 'valid-recaptcha-response',
+      };
+
+      await expect(
+        authService.submitHigherRequestLimitForm(dto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException if recaptcha verification fails', async () => {
+      vi.spyOn(configService, 'get').mockReturnValue('secret-key');
+      vi.mocked(validateRecaptcha).mockResolvedValue(false);
+
+      const dto: HigherRequestLimitDto = {
+        email: 'test@example.com',
+        reason: 'Need more requests',
+        requestedLimit: '1000',
+        api_key: 'valid-api-key',
+        'g-recaptcha-response': 'invalid-recaptcha-response',
+      };
+
+      await expect(
+        authService.submitHigherRequestLimitForm(dto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should send emails if recaptcha verification passes', async () => {
+      vi.spyOn(configService, 'get').mockReturnValue('secret-key');
+      vi.mocked(validateRecaptcha).mockResolvedValue(true);
+      const jwtServiceSpy = vi
+        .spyOn(jwtService, 'verify')
+        .mockReturnValue({ userId: 'user123' });
+
+      const dto: HigherRequestLimitDto = {
+        email: 'test@example.com',
+        reason: 'Need more requests',
+        requestedLimit: '1000',
+        api_key: 'valid-api-key',
+        'g-recaptcha-response': 'valid-recaptcha-response',
+      };
+
+      await authService.submitHigherRequestLimitForm(dto);
+
+      expect(validateRecaptcha).toHaveBeenCalledWith(
+        dto['g-recaptcha-response'],
+        'secret-key',
+      );
+      expect(jwtServiceSpy).toHaveBeenCalledWith(dto.api_key);
+      expect(sendEmail).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/xcm-api/src/auth/auth.service.ts
+++ b/apps/xcm-api/src/auth/auth.service.ts
@@ -51,9 +51,15 @@ export class AuthService {
   ) {}
 
   async generateApiKey(recaptcha: string) {
+    const recaptchaSecretKey = this.configService.get<string>(
+      'RECAPTCHA_SECRET_KEY',
+    );
+    if (!recaptchaSecretKey) {
+      throw new ForbiddenException('Recaptcha secret key is not set');
+    }
     const verificationResult = await validateRecaptcha(
       recaptcha,
-      this.configService.get('RECAPTCHA_SECRET_KEY'),
+      recaptchaSecretKey,
     );
     if (verificationResult) {
       const { id } = await this.usersService.create();
@@ -67,9 +73,15 @@ export class AuthService {
   }
 
   async submitHigherRequestLimitForm(dto: HigherRequestLimitDto) {
+    const recaptchaSecretKey = this.configService.get<string>(
+      'RECAPTCHA_SECRET_KEY',
+    );
+    if (!recaptchaSecretKey) {
+      throw new ForbiddenException('Recaptcha secret key is not set');
+    }
     const verificationResult = await validateRecaptcha(
       dto['g-recaptcha-response'],
-      this.configService.get('RECAPTCHA_SECRET_KEY'),
+      recaptchaSecretKey,
     );
     if (verificationResult) {
       const { userId } = this.jwtService.verify<{ userId: string }>(

--- a/apps/xcm-api/src/auth/utils/utils.ts
+++ b/apps/xcm-api/src/auth/utils/utils.ts
@@ -31,7 +31,7 @@ export const sendEmail = async (
       refreshToken,
       accessToken: myAccessToken.token,
     },
-  });
+  } as nodemailer.TransportOptions);
 
   transporter.sendMail(
     {

--- a/apps/xcm-api/src/balance/balance.controller.test.ts
+++ b/apps/xcm-api/src/balance/balance.controller.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { BalanceController } from './balance.controller.js';
+import { BalanceService } from './balance.service.js';
+import { AnalyticsService } from '../analytics/analytics.service.js';
+import { EventName } from '../analytics/EventName.js';
+import type { BalanceNativeDto } from './dto/BalanceNativeDto.js';
+import type { BalanceForeignDto } from './dto/BalanceForeignDto.js';
+
+describe('BalanceController', () => {
+  let balanceController: BalanceController;
+  let balanceService: BalanceService;
+  let analyticsService: AnalyticsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BalanceController],
+      providers: [
+        {
+          provide: BalanceService,
+          useValue: {
+            getBalanceNative: vi.fn(),
+            getBalanceForeign: vi.fn(),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            track: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    balanceController = module.get<BalanceController>(BalanceController);
+    balanceService = module.get<BalanceService>(BalanceService);
+    analyticsService = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  describe('getBalanceNative', () => {
+    it('should track analytics and call BalanceService for native balance', async () => {
+      const node = 'Acala';
+      const params: BalanceNativeDto = {
+        address: '0x1234567890',
+      };
+      const req = {} as Request;
+
+      const balanceNativeMock = 1000n;
+      const balanceServiceSpy = vi
+        .spyOn(balanceService, 'getBalanceNative')
+        .mockResolvedValue(balanceNativeMock);
+      const analyticsServiceSpy = vi.spyOn(analyticsService, 'track');
+
+      const result = await balanceController.getBalanceNative(
+        node,
+        params,
+        req,
+      );
+
+      expect(analyticsServiceSpy).toHaveBeenCalledWith(
+        EventName.GET_BALANCE_NATIVE,
+        req,
+        { node },
+      );
+      expect(balanceServiceSpy).toHaveBeenCalledWith(node, params);
+      expect(result).toEqual(balanceNativeMock);
+    });
+  });
+
+  describe('getBalanceForeign', () => {
+    it('should track analytics and call BalanceService for foreign balance', async () => {
+      const node = 'Acala';
+      const params: BalanceForeignDto = {
+        address: '0x1234567890',
+        currency: { symbol: 'UNQ' },
+      };
+      const req = {} as Request;
+
+      const balanceForeignMock = '500';
+      const balanceServiceSpy = vi
+        .spyOn(balanceService, 'getBalanceForeign')
+        .mockResolvedValue(balanceForeignMock);
+      const analyticsServiceSpy = vi.spyOn(analyticsService, 'track');
+
+      const result = await balanceController.getBalanceForeign(
+        node,
+        params,
+        req,
+      );
+
+      expect(analyticsServiceSpy).toHaveBeenCalledWith(
+        EventName.GET_BALANCE_FOREIGN,
+        req,
+        { node },
+      );
+      expect(balanceServiceSpy).toHaveBeenCalledWith(node, params);
+      expect(result).toEqual(balanceForeignMock);
+    });
+  });
+});

--- a/apps/xcm-api/src/balance/balance.controller.ts
+++ b/apps/xcm-api/src/balance/balance.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Param, Post, Req, Request } from '@nestjs/common';
+import { AnalyticsService } from '../analytics/analytics.service.js';
+import { EventName } from '../analytics/EventName.js';
+import { BalanceService } from './balance.service.js';
+import { ZodValidationPipe } from '../zod-validation-pipe.js';
+import {
+  BalanceNativeDto,
+  BalanceNativeDtoSchema,
+} from './dto/BalanceNativeDto.js';
+import {
+  BalanceForeignDto,
+  BalanceForeignDtoSchema,
+} from './dto/BalanceForeignDto.js';
+
+@Controller('balance')
+export class BalanceController {
+  constructor(
+    private balanceService: BalanceService,
+    private analyticsService: AnalyticsService,
+  ) {}
+
+  @Post(':node/native')
+  getBalanceNative(
+    @Param('node') node: string,
+    @Body(new ZodValidationPipe(BalanceNativeDtoSchema))
+    params: BalanceNativeDto,
+    @Req() req: Request,
+  ) {
+    this.analyticsService.track(EventName.GET_BALANCE_NATIVE, req, {
+      node,
+    });
+    return this.balanceService.getBalanceNative(node, params);
+  }
+
+  @Post(':node/foreign')
+  getBalanceForeign(
+    @Param('node') node: string,
+    @Body(new ZodValidationPipe(BalanceForeignDtoSchema))
+    params: BalanceForeignDto,
+    @Req() req: Request,
+  ) {
+    this.analyticsService.track(EventName.GET_BALANCE_FOREIGN, req, {
+      node,
+    });
+    return this.balanceService.getBalanceForeign(node, params);
+  }
+}

--- a/apps/xcm-api/src/balance/balance.module.ts
+++ b/apps/xcm-api/src/balance/balance.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { BalanceController } from './balance.controller.js';
+import { BalanceService } from './balance.service.js';
+
+@Module({
+  controllers: [BalanceController],
+  providers: [BalanceService],
+})
+export class BalanceModule {}

--- a/apps/xcm-api/src/balance/balance.service.test.ts
+++ b/apps/xcm-api/src/balance/balance.service.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { BalanceService } from './balance.service.js';
+import {
+  createApiInstanceForNode,
+  getBalanceForeign,
+  getBalanceNative,
+} from '@paraspell/sdk';
+import type { BalanceNativeDto } from './dto/BalanceNativeDto.js';
+import type { BalanceForeignDto } from './dto/BalanceForeignDto.js';
+import type { ApiPromise } from '@polkadot/api';
+
+vi.mock('@paraspell/sdk', () => ({
+  createApiInstanceForNode: vi.fn(),
+  getBalanceForeign: vi.fn(),
+  getBalanceNative: vi.fn(),
+  NODES_WITH_RELAY_CHAINS: ['valid-node'],
+}));
+
+describe('BalanceService', () => {
+  let balanceService: BalanceService;
+
+  beforeEach(() => {
+    balanceService = new BalanceService();
+  });
+
+  describe('getBalanceNative', () => {
+    it('should throw BadRequestException for an invalid node', async () => {
+      const invalidNode = 'invalid-node';
+      const params: BalanceNativeDto = { address: '0x1234567890' };
+
+      await expect(
+        balanceService.getBalanceNative(invalidNode, params),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should return native balance for a valid node', async () => {
+      const validNode = 'valid-node';
+      const params: BalanceNativeDto = { address: '0x1234567890' };
+      const mockApiInstance = { disconnect: vi.fn() } as unknown as ApiPromise;
+      const mockBalance = 1000n;
+
+      vi.mocked(createApiInstanceForNode).mockResolvedValue(mockApiInstance);
+      vi.mocked(getBalanceNative).mockResolvedValue(mockBalance);
+
+      const disconnectSpy = vi.spyOn(mockApiInstance, 'disconnect');
+
+      const result = await balanceService.getBalanceNative(validNode, params);
+
+      expect(createApiInstanceForNode).toHaveBeenCalledWith(validNode);
+      expect(getBalanceNative).toHaveBeenCalledWith(
+        params.address,
+        validNode,
+        mockApiInstance,
+      );
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(result).toEqual(mockBalance);
+    });
+  });
+
+  describe('getBalanceForeign', () => {
+    it('should throw BadRequestException for an invalid node', async () => {
+      const invalidNode = 'invalid-node';
+      const params: BalanceForeignDto = {
+        address: '0x1234567890',
+        currency: { symbol: 'UNQ' },
+      };
+
+      await expect(
+        balanceService.getBalanceForeign(invalidNode, params),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should return foreign balance as a string for a valid node', async () => {
+      const validNode = 'valid-node';
+      const params: BalanceForeignDto = {
+        address: '0x1234567890',
+        currency: { symbol: 'UNQ' },
+      };
+      const mockApiInstance = { disconnect: vi.fn() } as unknown as ApiPromise;
+      const mockBalance = 500n;
+
+      vi.mocked(createApiInstanceForNode).mockResolvedValue(mockApiInstance);
+      vi.mocked(getBalanceForeign).mockResolvedValue(mockBalance);
+
+      const disconnectSpy = vi.spyOn(mockApiInstance, 'disconnect');
+
+      const result = await balanceService.getBalanceForeign(validNode, params);
+
+      expect(createApiInstanceForNode).toHaveBeenCalledWith(validNode);
+      expect(getBalanceForeign).toHaveBeenCalledWith(
+        params.address,
+        validNode,
+        params.currency,
+        mockApiInstance,
+      );
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(result).toEqual(mockBalance.toString());
+    });
+
+    it('should return "null" if foreign balance is null', async () => {
+      const validNode = 'valid-node';
+      const params: BalanceForeignDto = {
+        address: '0x1234567890',
+        currency: { symbol: 'UNQ' },
+      };
+      const mockApiInstance = { disconnect: vi.fn() } as unknown as ApiPromise;
+
+      vi.mocked(createApiInstanceForNode).mockResolvedValue(mockApiInstance);
+      vi.mocked(getBalanceForeign).mockResolvedValue(null);
+
+      const disconnectSpy = vi.spyOn(mockApiInstance, 'disconnect');
+
+      const result = await balanceService.getBalanceForeign(validNode, params);
+
+      expect(createApiInstanceForNode).toHaveBeenCalledWith(validNode);
+      expect(getBalanceForeign).toHaveBeenCalledWith(
+        params.address,
+        validNode,
+        params.currency,
+        mockApiInstance,
+      );
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(result).toEqual('null');
+    });
+  });
+});

--- a/apps/xcm-api/src/balance/balance.service.ts
+++ b/apps/xcm-api/src/balance/balance.service.ts
@@ -1,0 +1,43 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  createApiInstanceForNode,
+  getBalanceForeign,
+  getBalanceNative,
+  NODES_WITH_RELAY_CHAINS,
+  TNodePolkadotKusama,
+  TNodeWithRelayChains,
+} from '@paraspell/sdk';
+import { BalanceNativeDto } from './dto/BalanceNativeDto.js';
+import { BalanceForeignDto } from './dto/BalanceForeignDto.js';
+
+@Injectable()
+export class BalanceService {
+  async getBalanceNative(node: string, { address }: BalanceNativeDto) {
+    const nodeTyped = node as TNodeWithRelayChains;
+    if (!NODES_WITH_RELAY_CHAINS.includes(nodeTyped)) {
+      throw new BadRequestException(
+        `Node ${node} is not valid. Check docs for valid nodes.`,
+      );
+    }
+    const api = await createApiInstanceForNode(nodeTyped);
+    const balance = await getBalanceNative(address, nodeTyped, api);
+    await api.disconnect();
+    return balance;
+  }
+
+  async getBalanceForeign(
+    node: string,
+    { address, currency }: BalanceForeignDto,
+  ) {
+    const nodeTyped = node as TNodePolkadotKusama;
+    if (!NODES_WITH_RELAY_CHAINS.includes(nodeTyped)) {
+      throw new BadRequestException(
+        `Node ${node} is not valid. Check docs for valid nodes.`,
+      );
+    }
+    const api = await createApiInstanceForNode(nodeTyped);
+    const balance = await getBalanceForeign(address, nodeTyped, currency, api);
+    await api.disconnect();
+    return balance === null ? 'null' : balance.toString();
+  }
+}

--- a/apps/xcm-api/src/balance/dto/BalanceForeignDto.ts
+++ b/apps/xcm-api/src/balance/dto/BalanceForeignDto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { CurrencyCoreSchema } from '../../x-transfer/dto/XTransferDto.js';
+
+export const BalanceForeignDtoSchema = z.object({
+  address: z.string().min(1, { message: 'Address is required' }),
+  currency: CurrencyCoreSchema,
+});
+
+export type BalanceForeignDto = z.infer<typeof BalanceForeignDtoSchema>;

--- a/apps/xcm-api/src/balance/dto/BalanceNativeDto.ts
+++ b/apps/xcm-api/src/balance/dto/BalanceNativeDto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const BalanceNativeDtoSchema = z.object({
+  address: z.string(),
+});
+
+export type BalanceNativeDto = z.infer<typeof BalanceNativeDtoSchema>;

--- a/apps/xcm-api/src/config/throttler.config.test.ts
+++ b/apps/xcm-api/src/config/throttler.config.test.ts
@@ -10,7 +10,18 @@ import { throttlerConfig } from './throttler.config.js';
 
 describe('throttlerConfig', () => {
   const mockConfigService = {
-    get: vi.fn(),
+    get: vi.fn().mockImplementation((key: string) => {
+      switch (key) {
+        case 'RATE_LIMIT_TTL_SEC':
+          return 60;
+        case 'RATE_LIMIT_REQ_COUNT_AUTH':
+          return 50;
+        case 'RATE_LIMIT_REQ_COUNT_PUBLIC':
+          return 20;
+        default:
+          throw new Error('Unknown key');
+      }
+    }),
   } as unknown as ConfigService;
 
   const mockHttpContext = {
@@ -53,7 +64,14 @@ describe('throttlerConfig', () => {
   });
 
   it('should return request limit from user-specific requestLimit when present', () => {
-    mockConfigService.get = vi.fn();
+    mockConfigService.get = vi.fn().mockImplementation((key: string) => {
+      switch (key) {
+        case 'RATE_LIMIT_TTL_SEC':
+          return 60;
+        default:
+          return undefined;
+      }
+    });
     mockHttpContext.getRequest = vi.fn().mockReturnValue({
       user: { requestLimit: 100 },
     } as RequestWithUser);

--- a/apps/xcm-api/src/router/dto/RouterDto.ts
+++ b/apps/xcm-api/src/router/dto/RouterDto.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { CurrencyCoreSchema } from '../../x-transfer/dto/XTransferDto.js';
-import type { TCurrencyCore } from '@paraspell/sdk';
 import { TransactionType } from '@paraspell/xcm-router';
 import { validateAmount } from '../../utils/validateAmount.js';
 
@@ -35,10 +34,3 @@ export const RouterDtoSchema = z.object({
 });
 
 export type RouterDto = z.infer<typeof RouterDtoSchema>;
-
-export type PatchedRouterDto = RouterDto & {
-  currencyFrom: TCurrencyCore;
-  currencyTo: TCurrencyCore;
-  recipientAddress: string;
-  injectorAddress: string;
-};

--- a/apps/xcm-api/src/router/router.controller.test.ts
+++ b/apps/xcm-api/src/router/router.controller.test.ts
@@ -3,8 +3,8 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { RouterController } from './router.controller.js';
 import { RouterService } from './router.service.js';
-import type { PatchedRouterDto } from './dto/RouterDto.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
+import type { RouterDto } from './dto/RouterDto.js';
 
 // Integration tests to ensure controller and service are working together
 describe('RouterController', () => {
@@ -33,7 +33,7 @@ describe('RouterController', () => {
 
   describe('generateXcmCall', () => {
     it('should call generateExtrinsics service method with correct parameters and return result', async () => {
-      const queryParams: PatchedRouterDto = {
+      const queryParams: RouterDto = {
         from: 'Astar',
         exchange: 'AcalaDex',
         to: 'Moonbeam',
@@ -60,7 +60,7 @@ describe('RouterController', () => {
     });
 
     it('should call generateExtrinsics service method with correct parameters and return result - hash', async () => {
-      const queryParams: PatchedRouterDto = {
+      const queryParams: RouterDto = {
         from: 'Astar',
         exchange: 'AcalaDex',
         to: 'Moonbeam',
@@ -87,7 +87,7 @@ describe('RouterController', () => {
     });
 
     it('should call generateExtrinsics service method with correct parameters and return result - V2 POST', async () => {
-      const queryParams: PatchedRouterDto = {
+      const queryParams: RouterDto = {
         from: 'Astar',
         exchange: 'AcalaDex',
         to: 'Moonbeam',

--- a/apps/xcm-api/src/router/router.controller.ts
+++ b/apps/xcm-api/src/router/router.controller.ts
@@ -8,7 +8,7 @@ import {
   Request,
 } from '@nestjs/common';
 import { RouterService } from './router.service.js';
-import { PatchedRouterDto } from './dto/RouterDto.js';
+import { RouterDto } from './dto/RouterDto.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
 import { EventName } from '../analytics/EventName.js';
 
@@ -22,41 +22,35 @@ export class RouterController {
   private trackAnalytics(
     eventName: EventName,
     req: Request,
-    params: PatchedRouterDto,
+    params: RouterDto,
   ) {
     const { from, exchange, to, currencyFrom, currencyTo, slippagePct } =
       params;
     this.analyticsService.track(eventName, req, {
       from,
-      exchange,
+      exchange: exchange ?? 'unknown',
       to,
       currencyFrom: JSON.stringify(currencyFrom),
       currencyTo: JSON.stringify(currencyTo),
-      slippagePct,
+      slippagePct: slippagePct ?? 'unknown',
     });
   }
 
   @Get('router')
-  generateExtrinsics(
-    @Query() queryParams: PatchedRouterDto,
-    @Req() req: Request,
-  ) {
+  generateExtrinsics(@Query() queryParams: RouterDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_ROUTER_EXTRINSICS, req, queryParams);
     return this.routerService.generateExtrinsics(queryParams);
   }
 
   @Post('router')
-  generateExtrinsicsV2(
-    @Body() queryParams: PatchedRouterDto,
-    @Req() req: Request,
-  ) {
+  generateExtrinsicsV2(@Body() queryParams: RouterDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_ROUTER_EXTRINSICS, req, queryParams);
     return this.routerService.generateExtrinsics(queryParams);
   }
 
   @Post('router-hash')
   generateExtrinsicsV2Hash(
-    @Body() queryParams: PatchedRouterDto,
+    @Body() queryParams: RouterDto,
     @Req() req: Request,
   ) {
     this.trackAnalytics(

--- a/apps/xcm-api/src/router/router.service.test.ts
+++ b/apps/xcm-api/src/router/router.service.test.ts
@@ -3,7 +3,7 @@ import { Test } from '@nestjs/testing';
 import { RouterService } from './router.service.js';
 import * as utils from '../utils.js';
 import * as spellRouter from '@paraspell/xcm-router';
-import type { PatchedRouterDto } from './dto/RouterDto.js';
+import type { RouterDto } from './dto/RouterDto.js';
 import {
   BadRequestException,
   InternalServerErrorException,
@@ -46,7 +46,7 @@ describe('RouterService', () => {
     (tx: Extrinsic) => TSerializedApiCall
   >;
 
-  const options: PatchedRouterDto = {
+  const options: RouterDto = {
     from: 'Astar',
     exchange: 'AcalaDex',
     to: 'Moonbeam',
@@ -128,7 +128,7 @@ describe('RouterService', () => {
     });
 
     it('should throw BadRequestException for invalid from node', async () => {
-      const modifiedOptions: PatchedRouterDto = {
+      const modifiedOptions: RouterDto = {
         ...options,
         from: invalidNode as TNode,
       };
@@ -143,7 +143,7 @@ describe('RouterService', () => {
     });
 
     it('should throw BadRequestException for invalid to node', async () => {
-      const modifiedOptions: PatchedRouterDto = {
+      const modifiedOptions: RouterDto = {
         ...options,
         to: invalidNode as TNode,
       };
@@ -158,7 +158,7 @@ describe('RouterService', () => {
     });
 
     it('should throw BadRequestException for invalid exchange node', async () => {
-      const modifiedOptions: PatchedRouterDto = {
+      const modifiedOptions: RouterDto = {
         ...options,
         exchange: invalidNode as TNode,
       };
@@ -173,7 +173,7 @@ describe('RouterService', () => {
     });
 
     it('should throw BadRequestException for invalid injector address', async () => {
-      const modifiedOptions: PatchedRouterDto = {
+      const modifiedOptions: RouterDto = {
         ...options,
         injectorAddress: invalidNode,
       };
@@ -188,7 +188,7 @@ describe('RouterService', () => {
     });
 
     it('should throw BadRequestException for invalid recipient address', async () => {
-      const modifiedOptions: PatchedRouterDto = {
+      const modifiedOptions: RouterDto = {
         ...options,
         recipientAddress: invalidNode,
       };

--- a/apps/xcm-api/src/router/router.service.ts
+++ b/apps/xcm-api/src/router/router.service.ts
@@ -8,7 +8,7 @@ import {
   NODES_WITH_RELAY_CHAINS,
   TNodeWithRelayChains,
 } from '@paraspell/sdk';
-import { PatchedRouterDto } from './dto/RouterDto.js';
+import { RouterDto } from './dto/RouterDto.js';
 import { isValidWalletAddress, serializeExtrinsic } from '../utils.js';
 import {
   EXCHANGE_NODES,
@@ -19,7 +19,7 @@ import {
 
 @Injectable()
 export class RouterService {
-  async generateExtrinsics(options: PatchedRouterDto, hashEnabled = false) {
+  async generateExtrinsics(options: RouterDto, hashEnabled = false) {
     const {
       from,
       exchange,

--- a/apps/xcm-api/src/transfer-info/dto/transfer-info.dto.ts
+++ b/apps/xcm-api/src/transfer-info/dto/transfer-info.dto.ts
@@ -1,4 +1,3 @@
-import type { TCurrencyCore } from '@paraspell/sdk';
 import { CurrencyCoreSchema } from '../../x-transfer/dto/XTransferDto.js';
 import { z } from 'zod';
 import { validateAmount } from '../../utils/validateAmount.js';
@@ -20,7 +19,3 @@ export const TransferInfoSchema = z.object({
 });
 
 export type TransferInfoDto = z.infer<typeof TransferInfoSchema>;
-
-export type PatchedTransferInfoDto = TransferInfoDto & {
-  currency: TCurrencyCore;
-};

--- a/apps/xcm-api/src/transfer-info/transfer-info.controller.test.ts
+++ b/apps/xcm-api/src/transfer-info/transfer-info.controller.test.ts
@@ -5,7 +5,7 @@ import { mockRequestObject } from '../testUtils.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
 import { TransferInfoController } from './transfer-info.controller.js';
 import { TransferInfoService } from './transfer-info.service.js';
-import type { PatchedTransferInfoDto } from './dto/transfer-info.dto.js';
+import type { TransferInfoDto } from './dto/transfer-info.dto.js';
 import type { TTransferInfo } from '@paraspell/sdk';
 
 describe('TransferInfoController', () => {
@@ -34,7 +34,7 @@ describe('TransferInfoController', () => {
 
   describe('generateXcmCall', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const queryParams: PatchedTransferInfoDto = {
+      const queryParams: TransferInfoDto = {
         origin: 'Acala',
         destination: 'Basilisk',
         accountOrigin: '5F5586mfsnM6durWRLptYt3jSUs55KEmahdodQ5tQMr9iY96',

--- a/apps/xcm-api/src/transfer-info/transfer-info.controller.ts
+++ b/apps/xcm-api/src/transfer-info/transfer-info.controller.ts
@@ -4,7 +4,7 @@ import { EventName } from '../analytics/EventName.js';
 import { ZodValidationPipe } from '../zod-validation-pipe.js';
 import { TransferInfoService } from './transfer-info.service.js';
 import {
-  PatchedTransferInfoDto,
+  TransferInfoDto,
   TransferInfoSchema,
 } from './dto/transfer-info.dto.js';
 
@@ -18,7 +18,7 @@ export class TransferInfoController {
   private trackAnalytics(
     eventName: EventName,
     req: Request,
-    params: PatchedTransferInfoDto,
+    params: TransferInfoDto,
   ) {
     const { origin, destination, currency, amount } = params;
     this.analyticsService.track(eventName, req, {
@@ -31,10 +31,7 @@ export class TransferInfoController {
 
   @Post()
   @UsePipes(new ZodValidationPipe(TransferInfoSchema))
-  async getTransferInfo(
-    @Body() params: PatchedTransferInfoDto,
-    @Req() req: Request,
-  ) {
+  async getTransferInfo(@Body() params: TransferInfoDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GET_TRANSFER_INFO, req, params);
     return await this.transferInfoService.getTransferInfo(params);
   }

--- a/apps/xcm-api/src/transfer-info/transfer-info.service.ts
+++ b/apps/xcm-api/src/transfer-info/transfer-info.service.ts
@@ -7,11 +7,10 @@ import {
   InvalidCurrencyError,
   NODES_WITH_RELAY_CHAINS_DOT_KSM,
   TNodeDotKsmWithRelayChains,
-  TTransferInfo,
   getTransferInfo,
 } from '@paraspell/sdk';
 import { isValidWalletAddress } from '../utils.js';
-import { PatchedTransferInfoDto } from './dto/transfer-info.dto.js';
+import { TransferInfoDto } from './dto/transfer-info.dto.js';
 
 @Injectable()
 export class TransferInfoService {
@@ -22,17 +21,17 @@ export class TransferInfoService {
     accountDestination,
     currency,
     amount,
-  }: PatchedTransferInfoDto) {
+  }: TransferInfoDto) {
     const originNode = origin as TNodeDotKsmWithRelayChains | undefined;
     const destNode = destination as TNodeDotKsmWithRelayChains | undefined;
 
-    if (!NODES_WITH_RELAY_CHAINS_DOT_KSM.includes(originNode)) {
+    if (originNode && !NODES_WITH_RELAY_CHAINS_DOT_KSM.includes(originNode)) {
       throw new BadRequestException(
         `Node ${originNode} is not valid. Check docs for valid nodes.`,
       );
     }
 
-    if (!NODES_WITH_RELAY_CHAINS_DOT_KSM.includes(destNode)) {
+    if (destNode && !NODES_WITH_RELAY_CHAINS_DOT_KSM.includes(destNode)) {
       throw new BadRequestException(
         `Node ${destNode} is not valid. Check docs for valid nodes.`,
       );
@@ -46,11 +45,10 @@ export class TransferInfoService {
       throw new BadRequestException('Invalid destination wallet address.');
     }
 
-    let response: TTransferInfo;
     try {
-      response = await getTransferInfo(
-        originNode,
-        destNode,
+      return await getTransferInfo(
+        originNode as TNodeDotKsmWithRelayChains,
+        destNode as TNodeDotKsmWithRelayChains,
         accountOrigin,
         accountDestination,
         currency,
@@ -64,6 +62,5 @@ export class TransferInfoService {
         throw new InternalServerErrorException(e.message);
       }
     }
-    return response;
   }
 }

--- a/apps/xcm-api/src/utils.test.ts
+++ b/apps/xcm-api/src/utils.test.ts
@@ -11,7 +11,6 @@ describe('isNumeric', () => {
   it('should return false for non-numeric values', () => {
     expect(isNumeric('abc')).toBe(false);
     expect(isNumeric('123abc')).toBe(false);
-    expect(isNumeric(undefined)).toBe(false);
   });
 });
 

--- a/apps/xcm-api/src/x-transfer-eth/dto/x-transfer-eth.dto.ts
+++ b/apps/xcm-api/src/x-transfer-eth/dto/x-transfer-eth.dto.ts
@@ -1,4 +1,3 @@
-import type { TCurrencyCore } from '@paraspell/sdk';
 import { CurrencyCoreSchema } from '../../x-transfer/dto/XTransferDto.js';
 import { z } from 'zod';
 import { validateAmount } from '../../utils/validateAmount.js';
@@ -19,7 +18,3 @@ export const XTransferEthDtoSchema = z.object({
 });
 
 export type XTransferEthDto = z.infer<typeof XTransferEthDtoSchema>;
-
-export type PatchedXTransferEthDto = XTransferEthDto & {
-  currency: TCurrencyCore;
-};

--- a/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.controller.test.ts
+++ b/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.controller.test.ts
@@ -6,7 +6,7 @@ import { AnalyticsService } from '../analytics/analytics.service.js';
 import type { TSerializedEthTransfer } from '@paraspell/sdk';
 import { XTransferEthController } from './x-transfer-eth.controller.js';
 import { XTransferEthService } from './x-transfer-eth.service.js';
-import type { PatchedXTransferEthDto } from './dto/x-transfer-eth.dto.js';
+import type { XTransferEthDto } from './dto/x-transfer-eth.dto.js';
 
 describe('XTransferEthController', () => {
   let controller: XTransferEthController;
@@ -34,11 +34,12 @@ describe('XTransferEthController', () => {
 
   describe('generateXcmCall', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const queryParams: PatchedXTransferEthDto = {
+      const queryParams: XTransferEthDto = {
         to: 'AssetHubPolkadot',
         amount: 100,
         address: '5F5586mfsnM6durWRLptYt3jSUs55KEmahdodQ5tQMr9iY96',
         currency: { symbol: 'WETH' },
+        destAddress: '0x5F5586mfsnM6durWRLptYt3jSUs55KEmahdodQ5tQMr9iY96',
       };
       const mockResult = {} as TSerializedEthTransfer;
       const spy = vi

--- a/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.controller.ts
+++ b/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.controller.ts
@@ -5,7 +5,7 @@ import { EventName } from '../analytics/EventName.js';
 import { ZodValidationPipe } from '../zod-validation-pipe.js';
 import {
   XTransferEthDtoSchema,
-  PatchedXTransferEthDto,
+  XTransferEthDto,
 } from './dto/x-transfer-eth.dto.js';
 
 @Controller('x-transfer-eth')
@@ -18,7 +18,7 @@ export class XTransferEthController {
   private trackAnalytics(
     eventName: EventName,
     req: Request,
-    params: PatchedXTransferEthDto,
+    params: XTransferEthDto,
   ) {
     const { to, address, currency } = params;
     this.analyticsService.track(eventName, req, {
@@ -30,10 +30,7 @@ export class XTransferEthController {
 
   @Post()
   @UsePipes(new ZodValidationPipe(XTransferEthDtoSchema))
-  generateXcmCall(
-    @Body() bodyParams: PatchedXTransferEthDto,
-    @Req() req: Request,
-  ) {
+  generateXcmCall(@Body() bodyParams: XTransferEthDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_ETH_CALL, req, bodyParams);
     return this.xTransferEthService.generateEthCall(bodyParams);
   }

--- a/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.service.test.ts
+++ b/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.service.test.ts
@@ -6,7 +6,7 @@ import {
 import type { TSerializedEthTransfer } from '@paraspell/sdk';
 import { buildEthTransferOptions } from '@paraspell/sdk';
 import { isValidPolkadotAddress } from '../utils.js';
-import type { PatchedXTransferEthDto } from './dto/x-transfer-eth.dto.js';
+import type { XTransferEthDto } from './dto/x-transfer-eth.dto.js';
 import { XTransferEthService } from './x-transfer-eth.service.js';
 
 vi.mock('@paraspell/sdk', () => ({
@@ -26,7 +26,7 @@ describe('XTransferEthService', () => {
   });
 
   it('should throw BadRequestException if the node is invalid', async () => {
-    const dto: PatchedXTransferEthDto = {
+    const dto: XTransferEthDto = {
       to: 'InvalidNode',
       amount: 100,
       address: '0xAddress',
@@ -43,7 +43,7 @@ describe('XTransferEthService', () => {
   });
 
   it('should throw BadRequestException if the destination address is invalid', async () => {
-    const dto: PatchedXTransferEthDto = {
+    const dto: XTransferEthDto = {
       to: 'Polkadot',
       amount: 100,
       address: '0xAddress',
@@ -62,7 +62,7 @@ describe('XTransferEthService', () => {
   });
 
   it('should return the result from buildEthTransferOptions for valid input', async () => {
-    const dto: PatchedXTransferEthDto = {
+    const dto: XTransferEthDto = {
       to: 'Polkadot',
       amount: 100,
       address: '0xAddress',
@@ -90,7 +90,7 @@ describe('XTransferEthService', () => {
   });
 
   it('should throw InternalServerErrorException when buildEthTransferOptions throws an error', async () => {
-    const dto: PatchedXTransferEthDto = {
+    const dto: XTransferEthDto = {
       to: 'Polkadot',
       amount: 100,
       address: '0xAddress',

--- a/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.service.ts
+++ b/apps/xcm-api/src/x-transfer-eth/x-transfer-eth.service.ts
@@ -9,7 +9,7 @@ import {
   buildEthTransferOptions,
 } from '@paraspell/sdk';
 import { isValidPolkadotAddress } from '../utils.js';
-import { PatchedXTransferEthDto } from './dto/x-transfer-eth.dto.js';
+import { XTransferEthDto } from './dto/x-transfer-eth.dto.js';
 
 @Injectable()
 export class XTransferEthService {
@@ -19,7 +19,7 @@ export class XTransferEthService {
     address,
     destAddress,
     currency,
-  }: PatchedXTransferEthDto) {
+  }: XTransferEthDto) {
     const toNode = to as TNodePolkadotKusama;
 
     if (!NODE_NAMES_DOT_KSM.includes(toNode)) {

--- a/apps/xcm-api/src/x-transfer/dto/XTransferBatchDto.ts
+++ b/apps/xcm-api/src/x-transfer/dto/XTransferBatchDto.ts
@@ -1,12 +1,9 @@
-import type { TAddress, TCurrencyInput } from '@paraspell/sdk';
 import { BatchMode } from '@paraspell/sdk';
 import { z } from 'zod';
 import { XTransferDtoSchema } from './XTransferDto.js';
 
-export const BatchModeSchema = z.nativeEnum(BatchMode);
-
 export const BatchOptionsSchema = z.object({
-  mode: BatchModeSchema.optional(),
+  mode: z.nativeEnum(BatchMode),
 });
 
 export const BatchXTransferDtoSchema = z.object({
@@ -16,14 +13,3 @@ export const BatchXTransferDtoSchema = z.object({
 
 export type TBatchOptions = z.infer<typeof BatchOptionsSchema>;
 export type BatchXTransferDto = z.infer<typeof BatchXTransferDtoSchema>;
-
-export type PatchedBatchXTransferDto = BatchXTransferDto & {
-  transfers: BatchXTransferDto['transfers'] &
-    {
-      currency: TCurrencyInput;
-      address: TAddress;
-    }[];
-  options?: BatchXTransferDto['options'] & {
-    mode: BatchMode;
-  };
-};

--- a/apps/xcm-api/src/x-transfer/dto/XTransferDto.ts
+++ b/apps/xcm-api/src/x-transfer/dto/XTransferDto.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import type { TAddress, TCurrencyInput } from '@paraspell/sdk';
 import { Version } from '@paraspell/sdk';
 import { MultiLocationSchema } from '@paraspell/xcm-analyser';
 import { validateAmount } from '../../utils/validateAmount.js';
@@ -82,8 +81,3 @@ export const XTransferDtoSchema = z.object({
 });
 
 export type XTransferDto = z.infer<typeof XTransferDtoSchema>;
-
-export type PatchedXTransferDto = XTransferDto & {
-  currency: TCurrencyInput;
-  address: TAddress;
-};

--- a/apps/xcm-api/src/x-transfer/x-transfer.controller.test.ts
+++ b/apps/xcm-api/src/x-transfer/x-transfer.controller.test.ts
@@ -5,9 +5,9 @@ import { XTransferController } from './x-transfer.controller.js';
 import { XTransferService } from './x-transfer.service.js';
 import { mockRequestObject } from '../testUtils.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
-import type { PatchedXTransferDto } from './dto/XTransferDto.js';
+import type { XTransferDto } from './dto/XTransferDto.js';
 import { BatchMode, type Extrinsic } from '@paraspell/sdk';
-import type { PatchedBatchXTransferDto } from './dto/XTransferBatchDto.js';
+import type { BatchXTransferDto } from './dto/XTransferBatchDto.js';
 
 // Integration tests to ensure controller and service are working together
 describe('XTransferController', () => {
@@ -36,7 +36,7 @@ describe('XTransferController', () => {
 
   describe('generateXcmCall', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const queryParams: PatchedXTransferDto = {
+      const queryParams: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount: 100,
@@ -60,7 +60,7 @@ describe('XTransferController', () => {
 
   describe('generateXcmCallV2', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const bodyParams: PatchedXTransferDto = {
+      const bodyParams: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount: '100',
@@ -84,7 +84,7 @@ describe('XTransferController', () => {
 
   describe('generateXcmCallV2Hash', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const bodyParams: PatchedXTransferDto = {
+      const bodyParams: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount: 100,
@@ -108,7 +108,7 @@ describe('XTransferController', () => {
 
   describe('generateXcmCallBatchHash', () => {
     it('should call generateXcmCall service method with correct parameters and return result', async () => {
-      const bodyParams: PatchedBatchXTransferDto = {
+      const bodyParams: BatchXTransferDto = {
         transfers: [
           {
             from: 'Acala',

--- a/apps/xcm-api/src/x-transfer/x-transfer.controller.ts
+++ b/apps/xcm-api/src/x-transfer/x-transfer.controller.ts
@@ -12,14 +12,10 @@ import { XTransferService } from './x-transfer.service.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
 import { EventName } from '../analytics/EventName.js';
 import { ZodValidationPipe } from '../zod-validation-pipe.js';
+import { XTransferDto, XTransferDtoSchema } from './dto/XTransferDto.js';
 import {
-  PatchedXTransferDto,
-  XTransferDto,
-  XTransferDtoSchema,
-} from './dto/XTransferDto.js';
-import {
+  BatchXTransferDto,
   BatchXTransferDtoSchema,
-  PatchedBatchXTransferDto,
 } from './dto/XTransferBatchDto.js';
 
 @Controller()
@@ -38,7 +34,7 @@ export class XTransferController {
     const resolvedCurrency = JSON.stringify(currency);
     const resolvedTo = JSON.stringify(to);
     this.analyticsService.track(eventName, req, {
-      from,
+      from: from ?? 'unknown',
       resolvedTo,
       resolvedCurrency,
     });
@@ -47,7 +43,7 @@ export class XTransferController {
   private trackAnalyticsBatch(
     eventName: EventName,
     req: Request,
-    params: PatchedBatchXTransferDto,
+    params: BatchXTransferDto,
   ) {
     const { transfers, options } = params;
     const resolvedTransfers = JSON.stringify(transfers);
@@ -60,30 +56,21 @@ export class XTransferController {
 
   @Get('x-transfer')
   @UsePipes(new ZodValidationPipe(XTransferDtoSchema))
-  generateXcmCall(
-    @Query() queryParams: PatchedXTransferDto,
-    @Req() req: Request,
-  ) {
+  generateXcmCall(@Query() queryParams: XTransferDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_XCM_CALL, req, queryParams);
     return this.xTransferService.generateXcmCall(queryParams);
   }
 
   @Post('x-transfer')
   @UsePipes(new ZodValidationPipe(XTransferDtoSchema))
-  generateXcmCallV2(
-    @Body() bodyParams: PatchedXTransferDto,
-    @Req() req: Request,
-  ) {
+  generateXcmCallV2(@Body() bodyParams: XTransferDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_XCM_CALL, req, bodyParams);
     return this.xTransferService.generateXcmCall(bodyParams);
   }
 
   @Post('x-transfer-hash')
   @UsePipes(new ZodValidationPipe(XTransferDtoSchema))
-  generateXcmCallV2Hash(
-    @Body() bodyParams: PatchedXTransferDto,
-    @Req() req: Request,
-  ) {
+  generateXcmCallV2Hash(@Body() bodyParams: XTransferDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_XCM_CALL_HASH, req, bodyParams);
     return this.xTransferService.generateXcmCall(bodyParams, true);
   }
@@ -91,7 +78,7 @@ export class XTransferController {
   @Post('x-transfer-batch')
   @UsePipes(new ZodValidationPipe(BatchXTransferDtoSchema))
   generateXcmCallBatchHash(
-    @Body() bodyParams: PatchedBatchXTransferDto,
+    @Body() bodyParams: BatchXTransferDto,
     @Req() req: Request,
   ) {
     this.trackAnalyticsBatch(

--- a/apps/xcm-api/src/x-transfer/x-transfer.service.test.ts
+++ b/apps/xcm-api/src/x-transfer/x-transfer.service.test.ts
@@ -2,7 +2,8 @@ import { vi, describe, expect, it, beforeEach } from 'vitest';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { XTransferService } from './x-transfer.service.js';
-import type { PatchedBatchXTransferDto } from './dto/XTransferBatchDto.js';
+import type { XTransferDto } from './dto/XTransferDto.js';
+import type { BatchXTransferDto } from './dto/XTransferBatchDto.js';
 import {
   BadRequestException,
   InternalServerErrorException,
@@ -10,7 +11,6 @@ import {
 import * as paraspellSdk from '@paraspell/sdk';
 import type { TNode } from '@paraspell/sdk';
 import { InvalidCurrencyError, createApiInstanceForNode } from '@paraspell/sdk';
-import type { PatchedXTransferDto } from './dto/XTransferDto.js';
 
 const builderMock = {
   from: vi.fn().mockReturnThis(),
@@ -58,7 +58,7 @@ describe('XTransferService', () => {
     it('should generate XCM call for parachain to parachain transfer', async () => {
       const from: TNode = 'Acala';
       const to: TNode = 'Basilisk';
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from,
         to,
         amount,
@@ -81,7 +81,7 @@ describe('XTransferService', () => {
     it('should generate XCM call for parachain to relaychain transfer', async () => {
       const from: TNode = 'Acala';
 
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from,
         amount,
         address,
@@ -100,7 +100,7 @@ describe('XTransferService', () => {
 
     it('should generate XCM call for relaychain to parachain transfer', async () => {
       const to: TNode = 'Acala';
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         to,
         amount,
         address,
@@ -118,7 +118,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException for invalid from node', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from: invalidNode,
         amount,
         address,
@@ -132,7 +132,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException for invalid to node', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         to: invalidNode,
         amount,
         address,
@@ -146,7 +146,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException when from and to node are missing', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         amount,
         address,
         currency,
@@ -159,7 +159,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException for missing currency in parachain to parachain transfer', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount,
@@ -173,37 +173,8 @@ describe('XTransferService', () => {
       expect(createApiInstanceForNode).not.toHaveBeenCalled();
     });
 
-    // it('should throw BadRequestException for invalid currency', async () => {
-    //   const xTransferDto: PatchedXTransferDto = {
-    //     from: 'Acala',
-    //     to: 'Basilisk',
-    //     amount,
-    //     address,
-    //     currency: { symbol: 'UNKNOWN' },
-    //   };
-
-    //   const builderMock = {
-    //     from: vi.fn().mockReturnThis(),
-    //     to: vi.fn().mockReturnThis(),
-    //     currency: vi.fn().mockReturnThis(),
-    //     amount: vi.fn().mockReturnThis(),
-    //     address: vi.fn().mockReturnThis(),
-    //     buildSerializedApiCall: vi.fn().mockImplementation(() => {
-    //       throw new InvalidCurrencyError('');
-    //     }),
-    //   };
-    //   vi.spyOn(paraspellSdk, 'Builder').mockReturnValue(
-    //     builderMock as unknown as paraspellSdk.GeneralBuilder,
-    //   );
-
-    //   await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
-    //     BadRequestException,
-    //   );
-    //   expect(createApiInstanceForNode).toHaveBeenCalled();
-    // });
-
     it('should throw InternalServerError when uknown error occures in the SDK', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount,
@@ -236,7 +207,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw on invalid wallet address', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from: 'Acala',
         to: 'Basilisk',
         amount,
@@ -251,7 +222,7 @@ describe('XTransferService', () => {
     });
 
     it('should specify xcm version if provided', async () => {
-      const xTransferDto: PatchedXTransferDto = {
+      const xTransferDto: XTransferDto = {
         from: 'Acala',
         to: 'AssetHubPolkadot',
         amount,
@@ -303,7 +274,7 @@ describe('XTransferService', () => {
         builderMock as unknown as paraspellSdk.GeneralBuilder,
       );
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -340,7 +311,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException when transfers array is empty', async () => {
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [],
         options: {
           mode: paraspellSdk.BatchMode.BATCH_ALL,
@@ -354,7 +325,7 @@ describe('XTransferService', () => {
     });
 
     it('should throw BadRequestException when from and to are missing', async () => {
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             amount,
@@ -375,7 +346,7 @@ describe('XTransferService', () => {
       const from2: TNode = 'Basilisk';
       const to: TNode = 'Moonriver';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from: from1,
@@ -403,7 +374,7 @@ describe('XTransferService', () => {
     it('should throw BadRequestException for invalid from node', async () => {
       const to: TNode = 'Basilisk';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from: invalidNode,
@@ -424,7 +395,7 @@ describe('XTransferService', () => {
     it('should throw BadRequestException for invalid to node', async () => {
       const from: TNode = 'Acala';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -446,7 +417,7 @@ describe('XTransferService', () => {
       const from: TNode = 'Acala';
       const to: TNode = 'Basilisk';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -477,7 +448,7 @@ describe('XTransferService', () => {
             // currency is missing
           },
         ],
-      } as unknown as PatchedBatchXTransferDto;
+      } as unknown as BatchXTransferDto;
 
       await expect(service.generateBatchXcmCall(batchDto)).rejects.toThrow(
         BadRequestException,
@@ -504,7 +475,7 @@ describe('XTransferService', () => {
         builderMockWithError as unknown as paraspellSdk.GeneralBuilder,
       );
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -542,7 +513,7 @@ describe('XTransferService', () => {
         builderMockWithError as unknown as paraspellSdk.GeneralBuilder,
       );
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -574,7 +545,7 @@ describe('XTransferService', () => {
             currency,
           },
         ],
-      } as unknown as PatchedBatchXTransferDto;
+      } as unknown as BatchXTransferDto;
 
       await expect(service.generateBatchXcmCall(batchDto)).rejects.toThrow(
         BadRequestException,
@@ -587,7 +558,7 @@ describe('XTransferService', () => {
       const from: TNode = 'Acala';
       const invalidToNode = 'InvalidNode';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,
@@ -639,7 +610,8 @@ describe('XTransferService', () => {
             address,
           },
         ],
-      } as unknown as PatchedBatchXTransferDto;
+        options: undefined,
+      } as unknown as BatchXTransferDto;
 
       const result = await service.generateBatchXcmCall(batchDto);
 
@@ -656,7 +628,7 @@ describe('XTransferService', () => {
       const from: TNode = 'Acala';
       const to: TNode = 'Basilisk';
 
-      const batchDto: PatchedBatchXTransferDto = {
+      const batchDto: BatchXTransferDto = {
         transfers: [
           {
             from,

--- a/apps/xcm-api/src/xcm-analyser/xcm-analyser.service.test.ts
+++ b/apps/xcm-api/src/xcm-analyser/xcm-analyser.service.test.ts
@@ -36,7 +36,10 @@ describe('XcmAnalyserService', () => {
       }),
     ).toThrow(BadRequestException);
     expect(() =>
-      service.getMultiLocationPaths({ multilocation: null, xcm: null }),
+      service.getMultiLocationPaths({
+        multilocation: undefined,
+        xcm: undefined,
+      }),
     ).toThrow(BadRequestException);
   });
 

--- a/apps/xcm-api/src/xcm-analyser/xcm-analyser.service.ts
+++ b/apps/xcm-api/src/xcm-analyser/xcm-analyser.service.ts
@@ -28,7 +28,7 @@ export class XcmAnalyserService {
       if (multilocation) {
         return `"${convertMultilocationToUrl(multilocation)}"`;
       } else {
-        return convertXCMToUrls(xcm);
+        return convertXCMToUrls(xcm as unknown[]);
       }
     } catch (e) {
       if (e instanceof Error) {

--- a/apps/xcm-api/test/app.e2e-spec.ts
+++ b/apps/xcm-api/test/app.e2e-spec.ts
@@ -246,6 +246,62 @@ describe('XCM API (e2e)', () => {
         .get(parachainIdUnknownNodeUrl)
         .expect(400);
     });
+
+    it('should get native balance successfully', async () => {
+      const validRequest = {
+        address: '5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid',
+      };
+
+      return request(app.getHttpServer())
+        .post('/balance/Acala/native')
+        .send(validRequest)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toBeDefined();
+        });
+    });
+
+    it('should return 400 for invalid native balance request', async () => {
+      const invalidRequest = {
+        address: '5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid',
+      };
+
+      return request(app.getHttpServer())
+        .post('/balance/Node123/native')
+        .send(invalidRequest)
+        .expect(400);
+    });
+
+    it('should get foreign balance successfully', async () => {
+      const validRequest = {
+        address: '5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid',
+        currency: {
+          symbol: 'UNQ',
+        },
+      };
+
+      return request(app.getHttpServer())
+        .post('/balance/Acala/foreign')
+        .send(validRequest)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toBeDefined();
+        });
+    });
+
+    it('should return 400 for invalid foreign balance request', async () => {
+      const invalidRequest = {
+        address: '5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid',
+        currency: {
+          symbol: 'UNQ',
+        },
+      };
+
+      return request(app.getHttpServer())
+        .post('/balance/Node123/foreign')
+        .send(invalidRequest)
+        .expect(400);
+    });
   });
 
   describe('X-Transfer controller', () => {

--- a/apps/xcm-api/tsconfig.json
+++ b/apps/xcm-api/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "module": "nodenext",
+    "strict": true,
     "declaration": false,
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -13,10 +14,10 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": false,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "strictPropertyInitialization": false
   }
 }

--- a/packages/sdk/src/types/TMultiLocation.ts
+++ b/packages/sdk/src/types/TMultiLocation.ts
@@ -16,10 +16,11 @@ type NetworkId = string | null
 type BodyId = string | null
 type BodyPart = string | null
 type StringOrNumber = string | number
+type StringOrNumberOrBigInt = StringOrNumber | bigint
 type HexString = string
 
 export interface JunctionParachain {
-  Parachain: StringOrNumber | undefined
+  Parachain: StringOrNumberOrBigInt | undefined
 }
 
 interface JunctionAccountId32 {
@@ -32,7 +33,7 @@ interface JunctionAccountId32 {
 interface JunctionAccountIndex64 {
   AccountIndex64: {
     network: NetworkId
-    index: StringOrNumber
+    index: StringOrNumberOrBigInt
   }
 }
 
@@ -44,16 +45,16 @@ interface JunctionAccountKey20 {
 }
 
 interface JunctionPalletInstance {
-  PalletInstance: StringOrNumber
+  PalletInstance: StringOrNumberOrBigInt
 }
 
 interface JunctionGeneralIndex {
-  GeneralIndex: StringOrNumber
+  GeneralIndex: StringOrNumberOrBigInt
 }
 
 interface JunctionGeneralKey {
   GeneralKey: {
-    length: StringOrNumber
+    length: StringOrNumberOrBigInt
     data: HexString
   }
 }

--- a/packages/xcm-analyser/src/types.ts
+++ b/packages/xcm-analyser/src/types.ts
@@ -19,24 +19,24 @@ const StringOrNumber = z
   .string()
   .regex(/^(?:\d{1,3}(?:,\d{3})*|\d+)$/)
   .transform((s) => s.replace(/,/g, ''))
-  .or(z.number())
-  .or(z.bigint());
+  .or(z.number());
+const StringOrNumberOrBigInt = StringOrNumber.or(z.bigint());
 const HexString = z.string();
 
-export const JunctionParachain = z.object({ Parachain: StringOrNumber });
+export const JunctionParachain = z.object({ Parachain: StringOrNumberOrBigInt });
 export const JunctionAccountId32 = z.object({
   AccountId32: z.object({ network: NetworkId, id: HexString }),
 });
 export const JunctionAccountIndex64 = z.object({
-  AccountIndex64: z.object({ network: NetworkId, index: StringOrNumber }),
+  AccountIndex64: z.object({ network: NetworkId, index: StringOrNumberOrBigInt }),
 });
 export const JunctionAccountKey20 = z.object({
   AccountKey20: z.object({ network: NetworkId, key: HexString }),
 });
-export const JunctionPalletInstance = z.object({ PalletInstance: StringOrNumber });
-export const JunctionGeneralIndex = z.object({ GeneralIndex: StringOrNumber });
+export const JunctionPalletInstance = z.object({ PalletInstance: StringOrNumberOrBigInt });
+export const JunctionGeneralIndex = z.object({ GeneralIndex: StringOrNumberOrBigInt });
 export const JunctionGeneralKey = z.object({
-  GeneralKey: z.object({ length: StringOrNumber, data: HexString }),
+  GeneralKey: z.object({ length: StringOrNumberOrBigInt, data: HexString }),
 });
 export const JunctionOnlyChild = z.object({ OnlyChild: z.string() });
 export const JunctionPlurality = z.object({


### PR DESCRIPTION
Closes #399 

Example HTTP request:

### Native balance
**POST /balance/Acala/native**

body:

```json
{
  "address": "5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid",
}
```

### Foreign balance
**POST /balance/Acala/foreign**

body:

```json
{
  "address": "5EtHZF4E8QagNCz6naobCkCAUT52SbcEqaXiDUu2PjUHxZid",
  "currency": {
    "symbol": "UNQ"
  }
}
```

