### PR TITLE
feat(xcm-api): Add new API endpoints 🪄

### DIFF
--- a/apps/xcm-api/README.md
+++ b/apps/xcm-api/README.md
@@ -315,7 +315,13 @@ const response = await fetch('http://localhost:3001/assets/:node/para-id');
 const response = await fetch('http://localhost:3001/assets/:paraID?ecosystem=polkadot');
 
 //Retrieve a list of implemented Parachains
-const response = await fetch('http://localhost:3001/assets');
+const response = await fetch('http://localhost:3001/nodes');
+
+//Query list of node WS endpoints
+const response = await fetch('http://localhost:3001/ws-endpoints/:node ');
+
+//Query supported assets supported between two nodes
+const response = await fetch('http://localhost:3001/supported-assets?origin=:node&destination=:node');
 
 //Query native asset balance
 const response = await fetch("http://localhost:3001/balance/:node/native", {

--- a/apps/xcm-api/src/analytics/EventName.ts
+++ b/apps/xcm-api/src/analytics/EventName.ts
@@ -6,6 +6,7 @@ export enum EventName {
   GET_RELAYCHAIN_SYMBOL = 'Get Relaychain Symbol',
   GET_NATIVE_ASSETS = 'Get Native Assets',
   GET_OTHER_ASSETS = 'Get Other Assets',
+  GET_SUPPORTED_ASSETS = 'Get Supported Assets',
   GET_ALL_ASSETS_SYMBOLS = 'Get All Assets Symbols',
   GET_DECIMALS = 'Get Decimals',
   HAS_SUPPORT_FOR_ASSET = 'Has Support For Asset',

--- a/apps/xcm-api/src/app.module.ts
+++ b/apps/xcm-api/src/app.module.ts
@@ -24,6 +24,7 @@ import { TransferInfoModule } from './transfer-info/transfer-info.module.js';
 import { XcmAnalyserModule } from './xcm-analyser/xcm-analyser.module.js';
 import { XTransferEthModule } from './x-transfer-eth/x-transfer-eth.module.js';
 import { BalanceModule } from './balance/balance.module.js';
+import { NodeConfigsModule } from './node-configs/node-configs.module.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -40,6 +41,7 @@ const __dirname = path.dirname(__filename);
     AssetsModule,
     PalletsModule,
     BalanceModule,
+    NodeConfigsModule,
     AuthModule,
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRootAsync({

--- a/apps/xcm-api/src/assets/assets.controller.test.ts
+++ b/apps/xcm-api/src/assets/assets.controller.test.ts
@@ -3,8 +3,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { AssetsController } from './assets.controller.js';
 import { AssetsService } from './assets.service.js';
-import type { TNode, TNodeAssets } from '@paraspell/sdk';
-import { NODE_NAMES } from '@paraspell/sdk';
+import type { TAsset, TNode, TNodeAssets } from '@paraspell/sdk';
 import { AnalyticsService } from '../analytics/analytics.service.js';
 import { mockRequestObject } from '../testUtils.js';
 
@@ -34,20 +33,6 @@ describe('AssetsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
-  });
-
-  describe('getNodeNames', () => {
-    it('should return the list of node names', () => {
-      const mockResult = NODE_NAMES;
-      const spy = vi
-        .spyOn(assetsService, 'getNodeNames')
-        .mockReturnValue(mockResult);
-
-      const result = controller.getNodeNames(mockRequestObject);
-
-      expect(result).toBe(mockResult);
-      expect(spy).toHaveBeenCalled();
-    });
   });
 
   describe('getAssetsObject', () => {
@@ -208,6 +193,30 @@ describe('AssetsController', () => {
 
       expect(result).toBe(mockResult);
       expect(spy).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getSupportedAssets', () => {
+    it('should return supported assets for a valid node origin and destination', () => {
+      const nodeOrigin = 'Acala';
+      const nodeDestination = 'Karura';
+      const mockResult = [
+        {
+          symbol: 'DOT',
+          assetId: '1234',
+        },
+      ] as TAsset[];
+      const spy = vi
+        .spyOn(assetsService, 'getSupportedAssets')
+        .mockReturnValue(mockResult);
+
+      const result = controller.getSupportedAssets(
+        { origin: nodeOrigin, destination: nodeDestination },
+        mockRequestObject,
+      );
+
+      expect(result).toBe(mockResult);
+      expect(spy).toHaveBeenCalledWith(nodeOrigin, nodeDestination);
     });
   });
 });

--- a/apps/xcm-api/src/assets/assets.controller.ts
+++ b/apps/xcm-api/src/assets/assets.controller.ts
@@ -4,21 +4,16 @@ import { isNumeric } from '../utils.js';
 import { SymbolDto } from './dto/SymbolDto.js';
 import { AnalyticsService } from '../analytics/analytics.service.js';
 import { EventName } from '../analytics/EventName.js';
+import { SupportedAssetsDto } from './dto/SupportedAssetsDto.js';
 
-@Controller('assets')
+@Controller()
 export class AssetsController {
   constructor(
     private assetsService: AssetsService,
     private analyticsService: AnalyticsService,
   ) {}
 
-  @Get()
-  getNodeNames(@Req() req: Request) {
-    this.analyticsService.track(EventName.GET_NODE_NAMES, req);
-    return this.assetsService.getNodeNames();
-  }
-
-  @Get(':node')
+  @Get('assets/:node')
   getAssetsObject(
     @Param('node') nodeOrParaId: string,
     @Query('ecosystem') ecosystem: string | undefined,
@@ -40,7 +35,7 @@ export class AssetsController {
     return this.assetsService.getAssetsObject(nodeOrParaId);
   }
 
-  @Get(':node/id')
+  @Get('assets/:node/id')
   getAssetId(
     @Param('node') node: string,
     @Query() { symbol }: SymbolDto,
@@ -53,7 +48,7 @@ export class AssetsController {
     return this.assetsService.getAssetId(node, symbol);
   }
 
-  @Get(':node/relay-chain-symbol')
+  @Get('assets/:node/relay-chain-symbol')
   getRelayChainSymbol(@Param('node') node: string, @Req() req: Request) {
     this.analyticsService.track(EventName.GET_RELAYCHAIN_SYMBOL, req, {
       node,
@@ -61,7 +56,7 @@ export class AssetsController {
     return this.assetsService.getRelayChainSymbol(node);
   }
 
-  @Get(':node/native')
+  @Get('assets/:node/native')
   getNativeAssets(@Param('node') node: string, @Req() req: Request) {
     this.analyticsService.track(EventName.GET_NATIVE_ASSETS, req, {
       node,
@@ -69,7 +64,7 @@ export class AssetsController {
     return this.assetsService.getNativeAssets(node);
   }
 
-  @Get(':node/other')
+  @Get('assets/:node/other')
   getOtherAssets(@Param('node') node: string, @Req() req: Request) {
     this.analyticsService.track(EventName.GET_OTHER_ASSETS, req, {
       node,
@@ -77,7 +72,7 @@ export class AssetsController {
     return this.assetsService.getOtherAssets(node);
   }
 
-  @Get(':node/all-symbols')
+  @Get('assets/:node/all-symbols')
   getAllAssetsSymbol(@Param('node') node: string, @Req() req: Request) {
     this.analyticsService.track(EventName.GET_ALL_ASSETS_SYMBOLS, req, {
       node,
@@ -85,7 +80,7 @@ export class AssetsController {
     return this.assetsService.getAllAssetsSymbols(node);
   }
 
-  @Get(':node/decimals')
+  @Get('assets/:node/decimals')
   getDecimals(
     @Param('node') node: string,
     @Query() { symbol }: SymbolDto,
@@ -98,7 +93,7 @@ export class AssetsController {
     return this.assetsService.getDecimals(node, symbol);
   }
 
-  @Get(':node/has-support')
+  @Get('assets/:node/has-support')
   hasSupportForAsset(
     @Param('node') node: string,
     @Query() { symbol }: SymbolDto,
@@ -111,11 +106,22 @@ export class AssetsController {
     return this.assetsService.hasSupportForAsset(node, symbol);
   }
 
-  @Get(':node/para-id')
+  @Get('assets/:node/para-id')
   getParaId(@Param('node') node: string, @Req() req: Request) {
     this.analyticsService.track(EventName.GET_PARA_ID, req, {
       node,
     });
     return this.assetsService.getParaId(node);
+  }
+
+  @Get('supported-assets')
+  getSupportedAssets(
+    @Query() { origin, destination }: SupportedAssetsDto,
+    @Req() req: Request,
+  ) {
+    this.analyticsService.track(EventName.GET_SUPPORTED_ASSETS, req, {
+      origin,
+    });
+    return this.assetsService.getSupportedAssets(origin, destination);
   }
 }

--- a/apps/xcm-api/src/assets/assets.service.ts
+++ b/apps/xcm-api/src/assets/assets.service.ts
@@ -4,7 +4,6 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import {
-  NODE_NAMES,
   TNode,
   TNodePolkadotKusama,
   getAllAssetsSymbols,
@@ -15,6 +14,7 @@ import {
   getOtherAssets,
   getParaId,
   getRelayChainSymbol,
+  getSupportedAssets,
   getTNode,
   hasSupportForAsset,
 } from '@paraspell/sdk';
@@ -22,10 +22,6 @@ import { validateNode } from '../utils.js';
 
 @Injectable()
 export class AssetsService {
-  getNodeNames() {
-    return NODE_NAMES;
-  }
-
   getAssetsObject(node: string) {
     validateNode(node);
     return getAssetsObject(node as TNode);
@@ -92,5 +88,11 @@ export class AssetsService {
       );
     }
     return JSON.stringify(node);
+  }
+
+  getSupportedAssets(nodeOrigin: string, nodeDestination: string) {
+    validateNode(nodeOrigin, { withRelayChains: true });
+    validateNode(nodeDestination, { withRelayChains: true });
+    return getSupportedAssets(nodeOrigin as TNode, nodeDestination as TNode);
   }
 }

--- a/apps/xcm-api/src/assets/dto/SupportedAssetsDto.ts
+++ b/apps/xcm-api/src/assets/dto/SupportedAssetsDto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class SupportedAssetsDto {
+  @IsNotEmpty()
+  origin: string;
+
+  @IsNotEmpty()
+  destination: string;
+}

--- a/apps/xcm-api/src/node-configs/node-configs.controller.test.ts
+++ b/apps/xcm-api/src/node-configs/node-configs.controller.test.ts
@@ -1,0 +1,60 @@
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { NODES_WITH_RELAY_CHAINS, type TNode } from '@paraspell/sdk';
+import { AnalyticsService } from '../analytics/analytics.service.js';
+import { mockRequestObject } from '../testUtils.js';
+import { NodeConfigsController } from './node-configs.controller.js';
+import { NodeConfigsService } from './node-configs.service.js';
+
+describe('AssetsController', () => {
+  let controller: NodeConfigsController;
+  let service: NodeConfigsService;
+  const node: TNode = 'Acala';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NodeConfigsController],
+      providers: [
+        NodeConfigsService,
+        {
+          provide: AnalyticsService,
+          useValue: { get: () => '', track: vi.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<NodeConfigsController>(NodeConfigsController);
+    service = module.get<NodeConfigsService>(NodeConfigsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getNodeNames', () => {
+    it('should return the list of node names', () => {
+      const mockResult = NODES_WITH_RELAY_CHAINS;
+      const spy = vi.spyOn(service, 'getNodeNames').mockReturnValue(mockResult);
+
+      const result = controller.getNodeNames(mockRequestObject);
+
+      expect(result).toBe(mockResult);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getSupportedAssets', () => {
+    it('should return supported assets for a valid node origin and destination', () => {
+      const mockResult = ['wss://acala.com', 'wss://acala2.com'];
+      const spy = vi
+        .spyOn(service, 'getWsEndpoints')
+        .mockReturnValue(mockResult);
+
+      const result = controller.getWsEndpoints(node, mockRequestObject);
+
+      expect(result).toBe(mockResult);
+      expect(spy).toHaveBeenCalledWith(node);
+    });
+  });
+});

--- a/apps/xcm-api/src/node-configs/node-configs.controller.ts
+++ b/apps/xcm-api/src/node-configs/node-configs.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Param, Req, Request } from '@nestjs/common';
+import { NodeConfigsService } from './node-configs.service.js';
+import { AnalyticsService } from '../analytics/analytics.service.js';
+import { EventName } from '../analytics/EventName.js';
+
+@Controller()
+export class NodeConfigsController {
+  constructor(
+    private service: NodeConfigsService,
+    private analyticsService: AnalyticsService,
+  ) {}
+
+  @Get('nodes')
+  getNodeNames(@Req() req: Request) {
+    this.analyticsService.track(EventName.GET_NODE_NAMES, req);
+    return this.service.getNodeNames();
+  }
+
+  @Get('ws-endpoints/:node')
+  getWsEndpoints(@Param('node') node: string, @Req() req: Request) {
+    this.analyticsService.track(EventName.GET_NODE_NAMES, req);
+    return this.service.getWsEndpoints(node);
+  }
+}

--- a/apps/xcm-api/src/node-configs/node-configs.module.ts
+++ b/apps/xcm-api/src/node-configs/node-configs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { NodeConfigsService } from './node-configs.service.js';
+import { NodeConfigsController } from './node-configs.controller.js';
+
+@Module({
+  controllers: [NodeConfigsController],
+  providers: [NodeConfigsService],
+})
+export class NodeConfigsModule {}

--- a/apps/xcm-api/src/node-configs/node-configs.service.test.ts
+++ b/apps/xcm-api/src/node-configs/node-configs.service.test.ts
@@ -1,0 +1,49 @@
+import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import * as paraspellSdk from '@paraspell/sdk';
+import type { TNode } from '@paraspell/sdk';
+import { NodeConfigsService } from './node-configs.service.js';
+
+vi.mock('@paraspell/sdk', async () => {
+  const actual = await vi.importActual('@paraspell/sdk');
+  return {
+    ...actual,
+    getNodeProviders: vi.fn().mockImplementation(() => ['wss://acala.com']),
+  };
+});
+
+describe('AssetsService', () => {
+  let service: NodeConfigsService;
+  const node: TNode = 'Acala';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NodeConfigsService],
+    }).compile();
+
+    service = module.get<NodeConfigsService>(NodeConfigsService);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getNodeNames', () => {
+    it('should return the list of node names', () => {
+      const result = service.getNodeNames();
+      expect(result).toEqual(paraspellSdk.NODES_WITH_RELAY_CHAINS);
+    });
+  });
+
+  describe('getWsEndpoints', () => {
+    it('should return the list of WS endpoints for a given node', () => {
+      const result = service.getWsEndpoints(node);
+      expect(result).toEqual(paraspellSdk.getNodeProviders(node));
+    });
+  });
+});

--- a/apps/xcm-api/src/node-configs/node-configs.service.ts
+++ b/apps/xcm-api/src/node-configs/node-configs.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import {
+  NODES_WITH_RELAY_CHAINS,
+  TNodeDotKsmWithRelayChains,
+  getNodeProviders,
+} from '@paraspell/sdk';
+import { validateNode } from '../utils.js';
+
+@Injectable()
+export class NodeConfigsService {
+  getNodeNames() {
+    return NODES_WITH_RELAY_CHAINS;
+  }
+
+  getWsEndpoints(node: string) {
+    validateNode(node, { excludeEthereum: true, withRelayChains: true });
+    return getNodeProviders(node as TNodeDotKsmWithRelayChains);
+  }
+}

--- a/apps/xcm-api/src/utils.ts
+++ b/apps/xcm-api/src/utils.ts
@@ -4,7 +4,12 @@ import type {
   TNodePolkadotKusama,
   TSerializedApiCall,
 } from '@paraspell/sdk';
-import { NODE_NAMES, NODE_NAMES_DOT_KSM } from '@paraspell/sdk';
+import {
+  NODE_NAMES,
+  NODE_NAMES_DOT_KSM,
+  NODES_WITH_RELAY_CHAINS,
+  NODES_WITH_RELAY_CHAINS_DOT_KSM,
+} from '@paraspell/sdk';
 import { decodeAddress, encodeAddress } from '@polkadot/keyring';
 import { hexToU8a, isHex } from '@polkadot/util';
 import { isAddress } from 'web3-validator';
@@ -13,10 +18,15 @@ export const isNumeric = (num: string) => !isNaN(Number(num));
 
 export const validateNode = (
   node: string,
-  { excludeEthereum } = { excludeEthereum: false },
+  options: { excludeEthereum?: boolean; withRelayChains?: boolean } = {},
 ) => {
+  const { excludeEthereum = false, withRelayChains = false } = options;
   const nodeList = excludeEthereum ? NODE_NAMES_DOT_KSM : NODE_NAMES;
-  if (!nodeList.includes(node as TNodePolkadotKusama)) {
+  const withRelaysNodeList = excludeEthereum
+    ? NODES_WITH_RELAY_CHAINS_DOT_KSM
+    : NODES_WITH_RELAY_CHAINS;
+  const usedNodeList = withRelayChains ? withRelaysNodeList : nodeList;
+  if (!usedNodeList.includes(node as TNodePolkadotKusama)) {
     throw new BadRequestException(
       `Node ${node} is not valid. Check docs for valid nodes.`,
     );


### PR DESCRIPTION
Closes #438 
Closes #439 
Closes #443 

### Changes
- Endpoint that return all available nodes has been renamed from /assets to /nodes
- Added new /ws-endpoints/(node) GET query
- Added new /supported-assets?origin=(node)&destination=(node) GET query
