### PR TITLE
Fix missing receiver address input validation when sending from and to the same Network Pull Request

### DIFF
--- a/apps/playground/src/components/XcmTransfer/XcmTransferForm.tsx
+++ b/apps/playground/src/components/XcmTransfer/XcmTransferForm.tsx
@@ -120,8 +120,16 @@ const XcmTransferForm: FC<Props> = ({
     },
 
     validate: {
-      address: (value) =>
-        isValidWalletAddress(value) ? null : 'Invalid address',
+      address: (value, values) => {
+        if (!isValidWalletAddress(value)) {
+          return 'Invalid address';
+        }
+        // Prevent Transfer to the same address when origin and destination networks are the same
+        if (values.from === values.to && value === selectedAccount?.address) {
+          return 'Sender and receiver cannot be the same address when origin and destination networks are the same, please enter a different address for the receiver.';
+        }
+        return null;
+      },
       currencies: {
         currencyOptionId: (value, values, path) => {
           const index = Number(path.split('.')[1]);


### PR DESCRIPTION
# 🐞 Fix missing receiver address input validation when sending from and to the same Network Pull Request

## 📌 Related Issue


Closes #1090 


---

## 🛠️ Description of the Fix

Bug description: In this Pull Request, I fixed the missing receiver address input validation when sending from and to the same Network, users can no longer send from the same network and address again, this would save users funds in for of transaction fees.

- Fix summary:
I added a validation check that prevents users from being able to submit a transaction in a local transfer if they select the same origin and destination networks, and at the same time, the same sender and receiver addresses.
---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

<!--
Include your Polkadot Asset Hub address to receive a reward if eligible.
-->
Polkadot Asset Hub Address: `12uR6ZinxBstfeh9zX5d415Z29XkSfNR4Nfkn6afAusKc52n`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---

## 🧩 Additional Notes (Optional)

<!--
Add any additional information or context here.
-->
