### PR TITLE
Fix sending amount input validation to check negative amounts

### DIFF
--- a/apps/playground/src/components/AssetClaim/AssetClaimForm.tsx
+++ b/apps/playground/src/components/AssetClaim/AssetClaimForm.tsx
@@ -40,6 +40,9 @@ const AssetClaimForm: FC<Props> = ({ onSubmit, loading }) => {
     validate: {
       address: (value) =>
         isValidWalletAddress(value) ? null : 'Invalid address',
+      amount: (value) => {
+        return Number(value) > 0 ? null : 'Amount must be greater than 0';
+      },
     },
   });
 

--- a/apps/playground/src/components/EvmTransfer/EvmTransferForm.tsx
+++ b/apps/playground/src/components/EvmTransfer/EvmTransferForm.tsx
@@ -64,6 +64,9 @@ const EvmTransferForm: FC<Props> = ({ onSubmit, loading, provider }) => {
           : 'Invalid address',
       ahAddress: (value, values) =>
         values.from === 'Moonbeam' && values.to === 'Ethereum' && !value,
+      amount: (value) => {
+        return Number(value) > 0 ? null : 'Amount must be greater than 0';
+      },
     },
   });
 

--- a/apps/playground/src/components/XcmRouter/XcmRouterForm.tsx
+++ b/apps/playground/src/components/XcmRouter/XcmRouterForm.tsx
@@ -147,6 +147,9 @@ export const XcmRouterForm: FC<Props> = ({ onSubmit, loading }) => {
         }
         return null;
       },
+      amount: (value) => {
+        return Number(value) > 0 ? null : 'Amount must be greater than 0';
+      },
     },
     validateInputOnChange: ['exchange'],
   });

--- a/apps/playground/src/components/XcmTransfer/XcmTransferForm.tsx
+++ b/apps/playground/src/components/XcmTransfer/XcmTransferForm.tsx
@@ -148,6 +148,9 @@ const XcmTransferForm: FC<Props> = ({
           }
           return null;
         },
+        amount: (value) => {
+          return Number(value) > 0 ? null : 'Amount must be greater than 0';
+        },
       },
       feeAsset(value, values) {
         return !value && values.currencies.length > 1

--- a/apps/playground/src/components/XcmUtils/XcmUtilsForm.tsx
+++ b/apps/playground/src/components/XcmUtils/XcmUtilsForm.tsx
@@ -142,6 +142,9 @@ const XcmUtilsForm: FC<Props> = ({
           }
           return null;
         },
+        amount: (value) => {
+          return Number(value) > 0 ? null : 'Amount must be greater than 0';
+        },
       },
       feeAsset(value, values) {
         return !value && values.currencies.length > 1


### PR DESCRIPTION
# 🐞 Fix sending amount input validation to check negative amounts Pull Request

## 📌 Related Issue


Closes #1099 

---

## 🛠️ Description of the Fix
- Bug description:  In this finding, users are able to input negative amounts as the amount they are sending.
- Fix summary: In this fix, I updated the amount input validation to prompt users to change the amount they are sending to a positive integer if they mistakenly sends a negative amount

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `12uR6ZinxBstfeh9zX5d415Z29XkSfNR4Nfkn6afAusKc52n`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---


