### PR TITLE
feat(playground-router): auto-quote router amounts and add advanced custom assets

### DIFF
--- a/apps/playground/src/components/EstimatedAmountInfo.tsx
+++ b/apps/playground/src/components/EstimatedAmountInfo.tsx
@@ -1,0 +1,20 @@
+import { Center, rem, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+
+export const EstimatedAmountInfo = () => (
+  <Tooltip
+    label="Estimated amount. Final value may vary due to price, fees, and slippage."
+    position="top-end"
+    withArrow
+    transitionProps={{ transition: 'pop-bottom-right' }}
+  >
+    <Text component="div" style={{ cursor: 'help' }}>
+      <Center>
+        <IconInfoCircle
+          style={{ width: rem(18), height: rem(18) }}
+          stroke={1.5}
+        />
+      </Center>
+    </Text>
+  </Tooltip>
+);

--- a/apps/playground/src/components/XcmRouter/RouterCurrencySelector.tsx
+++ b/apps/playground/src/components/XcmRouter/RouterCurrencySelector.tsx
@@ -1,0 +1,172 @@
+import type { ComboboxItem } from '@mantine/core';
+import {
+  Checkbox,
+  JsonInput,
+  SegmentedControl,
+  Select,
+  Stack,
+  TextInput,
+} from '@mantine/core';
+import type { UseFormReturnType } from '@mantine/form';
+import { isRelayChain, type TChain } from '@paraspell/sdk';
+import type { FC } from 'react';
+import { useEffect, useMemo } from 'react';
+
+import type { CurrencyFieldMap } from '../../types';
+import type { TRouterFormValues } from './XcmRouterForm';
+
+type Props = {
+  form: UseFormReturnType<TRouterFormValues>;
+  side: 'from' | 'to';
+  currencyOptions: ComboboxItem[];
+};
+
+const isRelayChainSafe = (chain?: unknown): boolean => {
+  if (typeof chain !== 'string') return false;
+  return isRelayChain(chain as TChain);
+};
+
+export const RouterCurrencyPicker: FC<Props> = ({
+  form,
+  side,
+  currencyOptions,
+}) => {
+  const { from, to } = form.values;
+
+  const fields: CurrencyFieldMap = useMemo(
+    () =>
+      side === 'from'
+        ? {
+            isCustom: 'currencyFrom.isCustom',
+            type: 'currencyFrom.customType',
+            value: 'currencyFrom.customValue',
+            symbol: 'currencyFrom.customSymbolSpecifier',
+            optionId: 'currencyFrom.optionId',
+            label: 'From',
+          }
+        : {
+            isCustom: 'currencyTo.isCustom',
+            type: 'currencyTo.customType',
+            value: 'currencyTo.customValue',
+            symbol: 'currencyTo.customSymbolSpecifier',
+            optionId: 'currencyTo.optionId',
+            label: 'To',
+          },
+    [side],
+  );
+
+  const entry =
+    side === 'from' ? form.values.currencyFrom : form.values.currencyTo;
+
+  const isCustom = entry.isCustom;
+  const customType = entry.customType;
+
+  const isRelayToPara = isRelayChainSafe(from);
+  const isParaToRelay = isRelayChainSafe(to);
+
+  const isNotParaToPara = isRelayToPara || isParaToRelay;
+
+  const selectDisabledByTopology =
+    side === 'from' ? isRelayToPara : isParaToRelay;
+
+  useEffect(() => {
+    if (isCustom && !customType) {
+      form.setFieldValue(fields.type, 'id');
+    }
+  }, [isCustom, customType]);
+
+  useEffect(() => {
+    if (customType) {
+      form.setFieldValue(fields.value, '');
+    }
+  }, [customType]);
+
+  // If it's not para-to-para, we do not allow custom currencies
+  useEffect(() => {
+    if (isNotParaToPara && isCustom) {
+      form.setFieldValue(fields.isCustom, false);
+    }
+  }, [isNotParaToPara, isCustom]);
+
+  const options = [
+    { label: 'Asset ID', value: 'id' },
+    { label: 'Symbol', value: 'symbol' },
+    { label: 'Location', value: 'location' },
+  ];
+
+  const symbolSpecifierOptions = [
+    { label: 'Auto', value: 'auto' },
+    { label: 'Native', value: 'native' },
+    { label: 'Foreign', value: 'foreign' },
+  ];
+
+  return (
+    <Stack gap="xs">
+      {isCustom && (customType === 'id' || customType === 'symbol') && (
+        <TextInput
+          size="sm"
+          label={`Custom Currency ${fields.label}`}
+          placeholder={customType === 'id' ? 'Asset ID' : 'Symbol'}
+          required
+          {...form.getInputProps(fields.value)}
+        />
+      )}
+
+      {isCustom && customType === 'location' && (
+        <JsonInput
+          size="sm"
+          placeholder="Input JSON location or interior junctions"
+          formatOnBlur
+          autosize
+          minRows={10}
+          {...form.getInputProps(fields.value)}
+        />
+      )}
+
+      {!isCustom && (
+        <Select
+          key={`${from ?? ''}-${to ?? ''}-${side}`}
+          size="sm"
+          label={`Currency ${fields.label}`}
+          placeholder="Pick value"
+          data={currencyOptions}
+          allowDeselect={false}
+          disabled={selectDisabledByTopology}
+          searchable
+          required
+          data-testid={`select-currency-${side}`}
+          {...form.getInputProps(fields.optionId)}
+        />
+      )}
+
+      {!isNotParaToPara && (
+        <Stack gap="xs">
+          <Checkbox
+            size="xs"
+            label="Select custom asset"
+            {...form.getInputProps(fields.isCustom, {
+              type: 'checkbox',
+            })}
+          />
+
+          {isCustom && (
+            <SegmentedControl
+              size="xs"
+              data={options}
+              {...form.getInputProps(fields.type)}
+            />
+          )}
+
+          {isCustom && customType === 'symbol' && (
+            <SegmentedControl
+              size="xs"
+              w="100%"
+              data={symbolSpecifierOptions}
+              {...form.getInputProps(fields.symbol)}
+            />
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+};

--- a/apps/playground/src/types.ts
+++ b/apps/playground/src/types.ts
@@ -68,3 +68,34 @@ export type TRouterSubmitType =
   | 'getMinTransferableAmount'
   | 'getTransferableAmount'
   | 'dryRun';
+
+export type TCurrencyEntry = {
+  optionId: string;
+  isCustom: boolean;
+  customType?: 'id' | 'symbol' | 'location';
+  customValue?: string;
+  customSymbolSpecifier?: 'auto' | 'native' | 'foreign';
+};
+
+export type CurrencyFieldPath =
+  | 'currencyFrom.optionId'
+  | 'currencyFrom.isCustom'
+  | 'currencyFrom.customType'
+  | 'currencyFrom.customValue'
+  | 'currencyFrom.customSymbolSpecifier'
+  | 'currencyTo.optionId'
+  | 'currencyTo.isCustom'
+  | 'currencyTo.customType'
+  | 'currencyTo.customValue'
+  | 'currencyTo.customSymbolSpecifier';
+
+export type CurrencyFieldMap = {
+  isCustom: CurrencyFieldPath;
+  type: CurrencyFieldPath;
+  value: CurrencyFieldPath;
+  symbol: CurrencyFieldPath;
+  optionId: CurrencyFieldPath;
+  label: 'From' | 'To';
+};
+
+export type Side = 'from' | 'to';

--- a/apps/playground/src/utils/amountFormat.ts
+++ b/apps/playground/src/utils/amountFormat.ts
@@ -1,0 +1,56 @@
+import {
+  findAssetInfo,
+  getAssetDecimals,
+  type TAssetInfo,
+  type TChain,
+  type TCurrencyInput,
+  type TSubstrateChain,
+} from '@paraspell/sdk';
+
+const toNumber = (value?: number | string | null) =>
+  value == null ? null : Number(value);
+
+const toCurrencyInput = (asset: TAssetInfo): TCurrencyInput | null => {
+  if ('symbol' in asset && asset.symbol) {
+    return { symbol: asset.symbol };
+  }
+
+  if ('assetId' in asset && asset.assetId != null) {
+    return { id: asset.assetId };
+  }
+
+  if ('location' in asset && asset.location != null) {
+    return { location: asset.location };
+  }
+
+  return null;
+};
+
+const findDecimals = (
+  chain: TSubstrateChain | TChain,
+  asset: TAssetInfo,
+): number | null => {
+  const currencyInput = toCurrencyInput(asset);
+  if (!currencyInput) return null;
+
+  const resolvedAsset = findAssetInfo(chain, currencyInput, null);
+  return toNumber(resolvedAsset?.decimals);
+};
+
+export function resolveDecimals(
+  chain: TSubstrateChain | TChain,
+  asset: TAssetInfo,
+): number | null {
+  const explicit = toNumber(asset.decimals);
+  if (explicit != null) return explicit;
+
+  const resolved = findDecimals(chain, asset);
+  if (resolved != null) return resolved;
+
+  if (asset.symbol) {
+    const fallback = getAssetDecimals(chain, asset.symbol);
+    if (typeof fallback === 'number') return fallback;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!--
Please rename "Bug Fix" to what is applicable in your PR (In case this is not a Bug bounty fix PR, but rather it is a new feature or something else)
-->
# 🐞 New Feature Pull Request

## 📌 Related Issue

Closes #1159


---

## 🛠️ Description of the Fix


- Bug description: Asset selection issue in some scenarios while selecting assets with error message like: 
   Multiple matches found for symbol DOT. Please specify with Native() or Foreign() selector.
- Fix summary: I automatically added the best amount for both the Amount To and Amount From fields. The option to select a custom asset was also added. Additionally, I normalized the best amount so that it is returned with decimals.
@michaeldev5
---

## ✅ Checklist

- [x] My code follows the project's code style.
- [ ] I have added tests that prove my fix is effective (if applicable).
- [ ] I have updated the documentation where necessary.
- [ ] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

<!--
Include your Polkadot Asset Hub address to receive a reward if eligible.
-->
Polkadot Asset Hub Address: `13iQhsTpLbYz3tzyR4ht8Q7qeFSCvLibnXPMcCEoUwyFtQjb`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---

## 🧩 Additional Notes (Optional)

<!--
Add any additional information or context here.
-->
