### PR TITLE
fix(sdk-core): improve PAPI enhancer usage

### DIFF
--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -75,7 +75,7 @@ const keyFromWs = (ws: string | string[]): TClientKey => {
 const createPolkadotClient = (ws: string | string[], useLegacy: boolean): TPapiApi => {
   const options = useLegacy ? { innerEnhancer: withLegacy() } : {}
   const provider = getWsProvider(ws, options)
-  return createClient(withPolkadotSdkCompat(provider))
+  return createClient(useLegacy ? provider : withPolkadotSdkCompat(provider))
 }
 
 const leasePolkadotClient = (ws: string | string[], ttlMs: number, useLegacy: boolean) => {


### PR DESCRIPTION
It doesn't make sense to use the `withPolkadotSdkCompat` enhancer when using the `withLegacy`. In that case it's just overhead. I'm terribly sorry for having pushed these middlewares to the consumer. In v2 all this stuff will be taken care off behind the scenes.

Thanks for the great work that you are doing in here! Keep it up! 💪 