### PR TITLE
feat(xcm-router): Allow single element aray in exchange()

### DIFF
--- a/packages/xcm-router/src/builder/RouterBuilder.test.ts
+++ b/packages/xcm-router/src/builder/RouterBuilder.test.ts
@@ -8,7 +8,7 @@ import {
   getXcmFees,
   transfer,
 } from '../transfer';
-import type { TTransferOptions } from '../types';
+import type { TExchangeInput, TTransferOptions } from '../types';
 import { RouterBuilder } from './RouterBuilder';
 
 vi.mock('../transfer');
@@ -233,6 +233,37 @@ describe('Builder', () => {
         amount,
         senderAddress,
         recipientAddress,
+        slippagePct,
+      },
+      undefined,
+    );
+  });
+
+  it('should construct transactions using RouterBuilder with single element exchange array', async () => {
+    await RouterBuilder()
+      .from(from)
+      .exchange([exchange] as TExchangeInput)
+      .to(to)
+      .currencyFrom(currencyFrom)
+      .currencyTo(currencyTo)
+      .amount(amount)
+      .senderAddress(senderAddress)
+      .recipientAddress(recipientAddress)
+      .signer(signer)
+      .slippagePct(slippagePct)
+      .buildTransactions();
+
+    expect(buildApiTransactionsSpy).toHaveBeenCalledWith(
+      {
+        from,
+        exchange: [exchange],
+        to,
+        currencyFrom,
+        currencyTo,
+        amount,
+        senderAddress,
+        recipientAddress,
+        signer,
         slippagePct,
       },
       undefined,

--- a/packages/xcm-router/src/types/TRouter.ts
+++ b/packages/xcm-router/src/types/TRouter.ts
@@ -212,10 +212,7 @@ export type TDexConfig = {
 
 export type TAssetsRecord = Record<TExchangeChain, TDexConfig>;
 
-export type TExchangeInput =
-  | TExchangeChain
-  | [TExchangeChain, TExchangeChain, ...TExchangeChain[]]
-  | undefined;
+export type TExchangeInput = TExchangeChain | [TExchangeChain, ...TExchangeChain[]] | undefined;
 
 export type TTransactionType = 'TRANSFER' | 'SWAP' | 'SWAP_AND_TRANSFER';
 


### PR DESCRIPTION
<!--
Please rename "Bug Fix" to what is applicable in your PR (In case this is not a Bug bounty fix PR, but rather it is a new feature or something else)
-->
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

<!--
Please link to the issue that this PR resolves.
Example: Closes #123
-->
Closes #1364

---

## 🛠️ Description of the Fix

<!--
Briefly describe the bug and what you have changed to resolve it.
Explain the root cause if known and what was done to fix it.
-->
- Bug description:
- Fix summary:

---

## ✅ Checklist

- [ ] My code follows the project's code style.
- [ ] I have added tests that prove my fix is effective (if applicable).
- [ ] I have updated the documentation where necessary.
- [ ] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

<!--
Include your Polkadot Asset Hub address to receive a reward if eligible.
-->
Polkadot Asset Hub Address: `INSERT_ADDRESS_HERE`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---

## 🧩 Additional Notes (Optional)

<!--
Add any additional information or context here.
-->
