### PR TITLE
fix(xcm-api): Add error handling to existentialDeposit and convertSs5…

### DIFF
--- a/apps/xcm-api/src/address/address.service.ts
+++ b/apps/xcm-api/src/address/address.service.ts
@@ -2,11 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { convertSs58, SUBSTRATE_CHAINS, TSubstrateChain } from '@paraspell/sdk';
 
 import { validateChain } from '../utils.js';
+import { handleXcmApiError } from '../utils/error-handler.js';
 
 @Injectable()
 export class AddressService {
   convertSs58(address: string, chain: string) {
     validateChain(chain, SUBSTRATE_CHAINS);
-    return convertSs58(address, chain as TSubstrateChain);
+    try {
+      return convertSs58(address, chain as TSubstrateChain);
+    } catch (e) {
+      return handleXcmApiError(e);
+    }
   }
 }

--- a/apps/xcm-api/src/balance/balance.service.ts
+++ b/apps/xcm-api/src/balance/balance.service.ts
@@ -30,6 +30,10 @@ export class BalanceService {
 
   getExistentialDeposit(chain: string, { currency }: ExistentialDepositDto) {
     validateChain(chain, CHAINS);
-    return getExistentialDeposit(chain as TChain, currency);
+    try {
+      return getExistentialDeposit(chain as TChain, currency);
+    } catch (e) {
+      return handleXcmApiError(e);
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes two XCM API endpoints that were returning 500 Internal Server Error instead of 400 Bad Request for invalid inputs.

## Changes

- Added try-catch block to `getExistentialDeposit` method in `balance.service.ts`
- Added try-catch block to `convertSs58` method in `address.service.ts`  
- Added `handleXcmApiError` import to `address.service.ts`

Both endpoints now properly return 400 Bad Request with appropriate error messages when the SDK throws errors for invalid inputs.

## Testing

Both endpoints can be tested with:

1. `/v5/balance/:chain/existential-deposit` - invalid currency
2. `/v5/convert-ss58` - invalid address format

They now return 400 instead of 500.

Fixes #1613

## Polkadot Asset Hub Address

`12pErKFjTDfRUZ3Qbp8pYzGNEyEnbSFsonPY59mQbE1Sncs5`