### PR TITLE
fix: resolve 500 Internal Server Errors in router and address conversion

### DIFF
--- a/apps/xcm-api/src/router/router.controller.ts
+++ b/apps/xcm-api/src/router/router.controller.ts
@@ -39,6 +39,7 @@ export class RouterController {
   }
 
   @Post()
+  @UsePipes(new ZodValidationPipe(RouterDtoSchema))
   generateExtrinsics(@Body() params: RouterDto, @Req() req: Request) {
     this.trackAnalytics(EventName.GENERATE_ROUTER_EXTRINSICS, req, params);
     return this.routerService.generateExtrinsics(params);
@@ -52,6 +53,7 @@ export class RouterController {
   }
 
   @Post('best-amount-out')
+  @UsePipes(new ZodValidationPipe(RouterBestAmountOutSchema))
   getBestAmountOut(
     @Body() params: RouterBestAmountOutDto,
     @Req() req: Request,

--- a/apps/xcm-api/src/utils/error-handler.ts
+++ b/apps/xcm-api/src/utils/error-handler.ts
@@ -66,6 +66,12 @@ export const handleXcmApiError = (error: unknown): never => {
   }
 
   if (error instanceof Error) {
+    if (
+      error.message.includes('address') ||
+      error.message.includes('checksum')
+    ) {
+      throw new BadRequestException(error.message);
+    }
     throw new InternalServerErrorException(error.message);
   }
 


### PR DESCRIPTION
## Description
Fixes 500 Internal Server Errors on ambiguous asset selection and invalid address formats.
- Added `ZodValidationPipe` to `RouterController` endpoints to ensure input validation before processing.
- Updated `handleXcmApiError` to catch common SDK errors (address format, checksum) and return a `BadRequestException` instead of a 500 error.

## Related Issue
Fixes #1654

## Review Request
Tagging @michaeldev5 for review as per contribution guidelines.