### PR TITLE
fix(xcm-api): legacy best-amount-out compat + ss58 validationfix(xcm-api): best-amount-out legacy compat + ss58 400

### DIFF
--- a/apps/xcm-api/src/address/address.service.ts
+++ b/apps/xcm-api/src/address/address.service.ts
@@ -1,13 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { convertSs58, SUBSTRATE_CHAINS, TSubstrateChain } from '@paraspell/sdk';
 
-import { validateChain } from '../utils.js';
+import { isValidPolkadotAddress, validateChain } from '../utils.js';
 import { handleXcmApiError } from '../utils/error-handler.js';
 
 @Injectable()
 export class AddressService {
   convertSs58(address: string, chain: string) {
     validateChain(chain, SUBSTRATE_CHAINS);
+    // Ensure invalid addresses are always a 400, not a 500 bubbling from downstream code.
+    if (!isValidPolkadotAddress(address)) {
+      throw new BadRequestException('Invalid wallet address.');
+    }
     try {
       return convertSs58(address, chain as TSubstrateChain);
     } catch (e) {

--- a/apps/xcm-api/src/router/pipes/best-amount-out-compat.pipe.test.ts
+++ b/apps/xcm-api/src/router/pipes/best-amount-out-compat.pipe.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { BestAmountOutCompatPipe } from './best-amount-out-compat.pipe.js';
+
+describe('BestAmountOutCompatPipe', () => {
+  it('should keep non-object inputs unchanged', () => {
+    const pipe = new BestAmountOutCompatPipe();
+    expect(pipe.transform(null)).toBeNull();
+    expect(pipe.transform('x')).toBe('x');
+    expect(pipe.transform(123)).toBe(123);
+  });
+
+  it('should convert legacy v5-style payload into the new schema shape', () => {
+    const pipe = new BestAmountOutCompatPipe();
+    const out = pipe.transform({
+      fromChain: 'Astar',
+      toChain: 'BifrostPolkadot',
+      fromAsset: 'BNC',
+      toAsset: 'ASTR',
+      amount: '123',
+      exchange: 'HydrationDex',
+    }) as any;
+
+    expect(out.from).toBe('Astar');
+    expect(out.to).toBe('BifrostPolkadot');
+    expect(out.currencyFrom).toEqual({ symbol: 'BNC' });
+    expect(out.currencyTo).toEqual({ symbol: 'ASTR' });
+    expect(out.amount).toBe('123');
+    expect(out.exchange).toBe('HydrationDex');
+  });
+
+  it('should accept legacy assets as CurrencyCore objects', () => {
+    const pipe = new BestAmountOutCompatPipe();
+    const out = pipe.transform({
+      fromChain: 'Astar',
+      toChain: 'BifrostPolkadot',
+      fromAsset: { symbol: { type: 'Foreign', value: 'USDT' } },
+      toAsset: { id: 123 },
+      amount: '1',
+    }) as any;
+
+    expect(out.currencyFrom).toEqual({ symbol: { type: 'Foreign', value: 'USDT' } });
+    expect(out.currencyTo).toEqual({ id: 123 });
+  });
+
+  it('should throw a clean 400 for unrecognized legacy asset objects', () => {
+    const pipe = new BestAmountOutCompatPipe();
+    expect(() =>
+      pipe.transform({
+        fromChain: 'Astar',
+        toChain: 'BifrostPolkadot',
+        fromAsset: { foo: 'bar' },
+        toAsset: 'ASTR',
+        amount: '1',
+      }),
+    ).toThrow(/fromAsset must be a symbol string/i);
+  });
+
+  it('should map statemint alias to AssetHubPolkadot', () => {
+    const pipe = new BestAmountOutCompatPipe();
+    const out = pipe.transform({
+      fromChain: 'statemint',
+      toChain: 'Astar',
+      fromAsset: 'USDT',
+      toAsset: 'ASTR',
+      amount: '1',
+    }) as any;
+
+    expect(out.from).toBe('AssetHubPolkadot');
+  });
+});

--- a/apps/xcm-api/src/router/pipes/best-amount-out-compat.pipe.ts
+++ b/apps/xcm-api/src/router/pipes/best-amount-out-compat.pipe.ts
@@ -1,0 +1,81 @@
+import { BadRequestException, Injectable, type PipeTransform } from '@nestjs/common';
+
+// Backwards-compat for the legacy (v5-style) request body shape used by older clients.
+// It normalizes the legacy shape into the current RouterBestAmountOutSchema shape,
+// so the ZodValidationPipe can do strict validation and return clean 400s.
+@Injectable()
+export class BestAmountOutCompatPipe implements PipeTransform {
+  transform(value: unknown) {
+    if (!value || typeof value !== 'object') return value;
+
+    const v = value as Record<string, unknown>;
+
+    const isLegacyShape =
+      'fromChain' in v || 'toChain' in v || 'fromAsset' in v || 'toAsset' in v;
+    const alreadyNewShape = 'currencyFrom' in v || 'currencyTo' in v;
+
+    if (!isLegacyShape || alreadyNewShape) return value;
+
+    const fromChainRaw = v.fromChain;
+    const toChainRaw = v.toChain;
+    const fromAsset = v.fromAsset;
+    const toAsset = v.toAsset;
+    const amount = v.amount;
+    const exchange = v.exchange;
+    const options = v.options;
+
+    const from =
+      typeof fromChainRaw === 'string' ? normalizeChainAlias(fromChainRaw) : undefined;
+    const to =
+      typeof toChainRaw === 'string' ? normalizeChainAlias(toChainRaw) : undefined;
+
+    return {
+      ...v,
+      from,
+      to,
+      exchange,
+      currencyFrom: legacyAssetToCurrencyCore(fromAsset, 'fromAsset'),
+      currencyTo: legacyAssetToCurrencyCore(toAsset, 'toAsset'),
+      amount,
+      options,
+    };
+  }
+}
+
+const normalizeChainAlias = (chain: string) => {
+  // Keep this conservative: only map well-known historical aliases to current SDK chain names.
+  // Source of truth for the canonical names: @paraspell/sdk-common PARACHAINS list.
+  const key = chain.trim().toLowerCase();
+  switch (key) {
+    case 'statemint':
+      return 'AssetHubPolkadot';
+    case 'statemine':
+      return 'AssetHubKusama';
+    case 'westmint':
+      return 'AssetHubWestend';
+    case 'paseomint':
+      return 'AssetHubPaseo';
+    default:
+      return chain;
+  }
+};
+
+const legacyAssetToCurrencyCore = (asset: unknown, fieldName: string) => {
+  if (typeof asset === 'string') {
+    const symbol = asset.trim();
+    if (symbol) return { symbol };
+  }
+
+  if (!asset || typeof asset !== 'object') {
+    throw new BadRequestException(`${fieldName} is required.`);
+  }
+
+  const a = asset as Record<string, unknown>;
+  if ('symbol' in a) return { symbol: a.symbol };
+  if ('id' in a) return { id: a.id };
+  if ('location' in a) return { location: a.location };
+
+  throw new BadRequestException(
+    `${fieldName} must be a symbol string, or an object with symbol/id/location.`,
+  );
+};

--- a/apps/xcm-api/src/router/router.controller.ts
+++ b/apps/xcm-api/src/router/router.controller.ts
@@ -7,9 +7,11 @@ import {
   ExchangePairsDto,
   ExchangePairsSchema,
   RouterBestAmountOutDto,
+  RouterBestAmountOutSchema,
   RouterDto,
   RouterDtoSchema,
 } from './dto/RouterDto.js';
+import { BestAmountOutCompatPipe } from './pipes/best-amount-out-compat.pipe.js';
 import { RouterService } from './router.service.js';
 
 @Controller('router')
@@ -52,6 +54,10 @@ export class RouterController {
   }
 
   @Post('best-amount-out')
+  @UsePipes(
+    new BestAmountOutCompatPipe(),
+    new ZodValidationPipe(RouterBestAmountOutSchema),
+  )
   getBestAmountOut(
     @Body() params: RouterBestAmountOutDto,
     @Req() req: Request,


### PR DESCRIPTION
<!--
Please rename "Bug Fix" to what is applicable in your PR (In case this is not a Bug bounty fix PR, but rather it is a new feature or something else)
-->
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

<!--
Please link to the issue that this PR resolves.
Example: Closes #123
-->
Closes #

---

Fixes two 500s reported in #1654 by validating inputs and adding backward compatibility for legacy `/v5/router/best-amount-out` request bodies.

Changes
- `/v4/convert-ss58`: invalid SS58 addresses now return `400 Invalid wallet address.` instead of a 500 bubbling from downstream.
- - `/v5/router/best-amount-out`: accept legacy keys (`fromChain`, `toChain`, `fromAsset`, `toAsset`) and normalize them into the current schema (`from`, `to`, `currencyFrom`, `currencyTo`).
-   - Includes common chain alias mapping: `statemint/statemine/westmint/paseomint -> AssetHub*`.
-   - Provides clear 400s for unsupported legacy asset shapes.
- 
- Tests
- - `pnpm vitest run src/router/pipes/best-amount-out-compat.pipe.test.ts`
- 
- Notes
- - This keeps current payloads unchanged; only adds a compat layer + earlier validation.
- ## 🛠️ Description of the Fix

<!--
Briefly describe the bug and what you have changed to resolve it.
Explain the root cause if known and what was done to fix it.
-->
- Bug description:
- Fix summary:

---

## ✅ Checklist

- [ ] My code follows the project's code style.
- [ ] I have added tests that prove my fix is effective (if applicable).
- [ ] I have updated the documentation where necessary.
- [ ] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

<!--
Include your Polkadot Asset Hub address to receive a reward if eligible.
-->
Polkadot Asset Hub Address: `INSERT_ADDRESS_HERE`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---

## 🧩 Additional Notes (Optional)

<!--
Add any additional information or context here.
-->
