### PR TITLE
test (sdk-core): include all chain to Ethereum scenarios in e2e tests

### DIFF
--- a/packages/sdk-core/e2e/generateE2eTests.ts
+++ b/packages/sdk-core/e2e/generateE2eTests.ts
@@ -160,24 +160,6 @@ export const generateE2eTests = <TApi, TRes, TSigner>(
       })
     })
 
-    describeGroup('Ethereum transfers', async () => {
-      const ethAssets = getOtherAssets('AssetHubPolkadot').filter(asset =>
-        hasJunction(asset.location, 'GlobalConsensus', {
-          Ethereum: { chainId: 1 }
-        })
-      )
-      ethAssets.forEach(asset => {
-        it(`should create transfer tx - ${asset.symbol} from AssetHubPolkadot to Ethereum`, async () => {
-          const builder = Builder(config)
-            .from('AssetHubPolkadot')
-            .to('Ethereum')
-            .currency({ location: asset.location, amount: MOCK_AMOUNT })
-            .address(MOCK_ETH_ADDRESS)
-            .senderAddress(MOCK_ADDRESS)
-          await validateTransfer(builder, signer)
-        })
-      })
-    })
 
     describeGroup('RelayToPara', () => {
       RELAYCHAINS.forEach(relayChain => {

--- a/packages/sdk-core/e2e/utils.ts
+++ b/packages/sdk-core/e2e/utils.ts
@@ -2,9 +2,11 @@ import {
   findAssetInfo,
   getAssets,
   getNativeAssetSymbol,
-  getRelayChainSymbol
+  getRelayChainSymbol,
+  getOtherAssets
 } from '@paraspell/assets'
-import { SUBSTRATE_CHAINS, TChain, TSubstrateChain } from '@paraspell/sdk-common'
+import { hasJunction } from '@paraspell/sdk-common'
+import { CHAINS, TChain, TSubstrateChain } from '@paraspell/sdk-common'
 import { getChain } from '../src'
 
 const supportsOnlyNativeAsset: TChain[] = ['Nodle']
@@ -22,26 +24,38 @@ export const doesNotSupportParaToRelay: TChain[] = [
 export const generateTransferScenarios = (originChain: TSubstrateChain, includeAll = false) => {
   const scenarios = []
   const allAssets = getAssets(originChain)
-
   const isNativeOnly = supportsOnlyNativeAsset.includes(originChain)
   const isAssetIdRequired = assetIdRequired.includes(originChain)
 
-  for (const destChain of SUBSTRATE_CHAINS) {
-    if (destChain === originChain) continue
+  for (const destChain of CHAINS) {
+    if (destChain === 'Ethereum' || destChain === 'EthereumTestnet' || destChain === originChain) continue
     const chainInstance = getChain(destChain)
     if (chainInstance.isReceivingTempDisabled('RelayToPara')) continue
     if (getRelayChainSymbol(originChain) !== getRelayChainSymbol(destChain)) continue
-
     // Loop through assets to find the first compatible one
     for (const asset of allAssets) {
       if (isNativeOnly && asset.symbol !== getNativeAssetSymbol(originChain)) continue
       if (isAssetIdRequired && asset.isNative) continue
-
       if (findAssetInfo(destChain, { location: asset.location }, null)) {
         scenarios.push({ originChain, destChain, asset })
         if (!includeAll) break
       }
     }
+  }
+
+  // Chain -> Ethereum scenarios
+  function hasTransferToEthereum(obj: unknown): obj is { transferToEthereum: Function } {
+    return !!obj && typeof (obj as any).transferToEthereum === 'function'
+  }
+  const chainInstance = getChain(originChain)
+  const supportsEthereum = hasTransferToEthereum(chainInstance)
+  if (supportsEthereum) {
+    const ethAssets = getOtherAssets(originChain).filter(asset =>
+      hasJunction(asset.location, 'GlobalConsensus', { Ethereum: { chainId: 1 } })
+    )
+    ethAssets.forEach(asset => {
+      scenarios.push({ originChain, destChain: 'Ethereum', asset })
+    })
   }
 
   return scenarios


### PR DESCRIPTION
<!--
Please rename "Bug Fix" to what is applicable in your PR (In case this is not a Bug bounty fix PR, but rather it is a new feature or something else)
-->
# 🚀 Feature Pull Request

## 📌 Related Issue

Closes #1687


- Added e2e tests for all chain → Ethereum scenarios in SDK-core.
- Updated test:e2e script for proper test execution.
- Logic follows code-based eligibility and maintainer guidance.
Explain the root cause if known and what was done to fix it.
-->
- Bug description:
- Fix summary:

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `12pErKFjTDfRUZ3Qbp8pYzGNEyEnbSFsonPY59mQbE1Sncs5`

> ⚠️ **Important:**  
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).  
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---



