### PR TITLE
Fix: Wrap AccountId().enc() error in InvalidAddressError for 400 response

### DIFF
--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -125,7 +125,12 @@ class PapiApi extends PolkadotApi<TPapiApi, TPapiTransaction, TPapiSigner> {
 
   accountToHex(address: string, isPrefixed = true) {
     if (isHex(address)) return address
-    const hex = toHex(AccountId().enc(address))
+    let hex
+    try {
+      hex = toHex(AccountId().enc(address))
+    } catch {
+      throw new InvalidAddressError(`Invalid address: ${address}`)
+    }
     return isPrefixed ? hex : hex.slice(2)
   }
 


### PR DESCRIPTION
## Description

Fixes #1466

`AccountId().enc()` throws a generic `Error` with "Invalid checksum" when decoding invalid substrate addresses. The SDK's `handleXcmApiError` only recognizes `InvalidAddressError` as a 400-level error, so this generic error falls through to `InternalServerErrorException` (500).

## Fix

Wrap the `AccountId().enc()` call in `accountToHex()` in a try-catch block and throw `InvalidAddressError` instead.

## Testing

- [ ] Invalid addresses now return 400 Bad Request
- [ ] Valid addresses continue to work unchanged