### PR TITLE
fix(xcm-analyser): handle Here locations

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ZodError } from 'zod';
 
 import { type Location } from '../types';
-import { convertLocationToUrl, convertXCMToUrls } from './convert';
+import { convertLocationToUrl, convertLocationToUrlJson, convertXCMToUrls } from './convert';
 
 describe('convert', () => {
   it('convert location to URL', () => {
@@ -41,6 +41,38 @@ describe('convert', () => {
 
     const result = convertLocationToUrl(location);
     expect(result).toBe('../../../PalletInstance(50)/GeneralIndex(41)');
+  });
+
+  it('convert local Here location to the current URL', () => {
+    const location: Location = {
+      parents: '0',
+      interior: 'Here',
+    };
+
+    const result = convertLocationToUrl(location);
+    expect(result).toBe('./');
+  });
+
+  it('convert parent Here location object to the parent URL', () => {
+    const location: Location = {
+      parents: '1',
+      interior: {
+        Here: null,
+      },
+    };
+
+    const result = convertLocationToUrl(location);
+    expect(result).toBe('../');
+  });
+
+  it('convert Here location JSON to the current URL', () => {
+    const locationJson = JSON.stringify({
+      parents: 0,
+      interior: 'Here',
+    });
+
+    const result = convertLocationToUrlJson(locationJson);
+    expect(result).toBe('./');
   });
 
   it('convert location to URL with parachain interior', () => {
@@ -269,6 +301,22 @@ describe('convert', () => {
 
     const result = convertXCMToUrls(xcmCallArguments);
     expect(result).toStrictEqual([]);
+  });
+
+  it('convert nested Here location from tx arguments', () => {
+    const xcmCallArguments = [
+      {
+        V4: {
+          parents: 1,
+          interior: {
+            Here: null,
+          },
+        },
+      },
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+    expect(result).toStrictEqual(['../']);
   });
 
   it('convert location to URL with X2 with 3 elements', () => {

--- a/packages/xcm-analyser/src/converter/convert.ts
+++ b/packages/xcm-analyser/src/converter/convert.ts
@@ -23,6 +23,11 @@ export const convertLocationToUrlJson = (locationJson: string): string => {
 export const convertLocationToUrl = (args: unknown): string => {
   const { parents, interior } = LocationSchema.parse(args);
   const parentsNum = Number(parents);
+  const pathStart = parentsNum > 0 ? '../'.repeat(parentsNum) : './';
+
+  if (interior === 'Here' || 'Here' in interior) {
+    return pathStart;
+  }
 
   const entries = Object.entries(interior);
   if (entries.length === 0) throw new Error('Interior is empty');
@@ -33,7 +38,6 @@ export const convertLocationToUrl = (args: unknown): string => {
 
   if (!isX1 && junctions.length === 0) throw new Error('Junction array is empty');
 
-  const pathStart = parentsNum > 0 ? '../'.repeat(parentsNum) : './';
   const path = (isX1 ? [junctions] : junctions)
     .map((junction) => convertJunctionToReadable(junction))
     .join('/');


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #1971

---

## 🛠️ Description of the Fix

- Bug description: Valid `Here` interiors pass `LocationSchema`, but the converter treats them as X1-X8 junctions and throws instead of producing a relative URL.
- Fix summary: Return the parent-relative path before junction parsing for both supported `Here` representations. Add regression coverage for direct, JSON, and nested XCM conversion APIs.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Will provide a non-CEX AssetHub Polkadot address before reward processing.

---

## 🧩 Additional Notes

@michaeldev5, please review.

Verification completed locally:

- `pnpm --filter @paraspell/xcm-analyser test` (86 tests passed)
- `pnpm --filter @paraspell/xcm-analyser compile`
- `pnpm --filter @paraspell/xcm-analyser lint:check`
- `pnpm --filter @paraspell/xcm-analyser format:check`
- `pnpm --filter @paraspell/xcm-analyser build`
- Direct checks against the built ESM exports for shorthand, object, JSON, and nested `Here` inputs