### PR TITLE
fix(sdk-core): share concurrent client leases

### DIFF
--- a/packages/sdk-core/src/api/clientPool.test.ts
+++ b/packages/sdk-core/src/api/clientPool.test.ts
@@ -52,6 +52,37 @@ describe('clientPool', () => {
     expect(reviveSpy).toHaveBeenNthCalledWith(2, keyFromWs(ws), 1_000)
   })
 
+  it('leaseClient shares in-flight creation for concurrent leases', async () => {
+    const pingClient = vi.fn().mockResolvedValue(undefined)
+    const cache = createClientCache<TFakeClient>(10, pingClient)
+    const createClient = vi.fn().mockResolvedValueOnce({ id: 1 }).mockResolvedValueOnce({ id: 2 })
+    const { leaseClient } = createClientPoolHelpers(cache, createClient)
+    const ws = 'wss://node'
+
+    const [c1, c2] = await Promise.all([leaseClient(ws, 1_000), leaseClient(ws, 1_000)])
+
+    expect(createClient).toHaveBeenCalledTimes(1)
+    expect(c2).toBe(c1)
+    expect(cache.peek(keyFromWs(ws))?.refs).toBe(2)
+  })
+
+  it('leaseClient retries creation after an in-flight failure', async () => {
+    const pingClient = vi.fn().mockResolvedValue(undefined)
+    const cache = createClientCache<TFakeClient>(10, pingClient)
+    const createClient = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection failed'))
+      .mockResolvedValueOnce({ id: 1 })
+    const { leaseClient } = createClientPoolHelpers(cache, createClient)
+    const ws = 'wss://node'
+
+    await expect(leaseClient(ws, 1_000)).rejects.toThrow('connection failed')
+    await expect(leaseClient(ws, 1_000)).resolves.toEqual({ id: 1 })
+
+    expect(createClient).toHaveBeenCalledTimes(2)
+    expect(cache.peek(keyFromWs(ws))?.refs).toBe(1)
+  })
+
   it('leaseClient resets destroyWanted to false', async () => {
     const pingClient = vi.fn().mockResolvedValue(undefined)
     const cache = createClientCache<TFakeClient>(10, pingClient)

--- a/packages/sdk-core/src/api/clientPool.ts
+++ b/packages/sdk-core/src/api/clientPool.ts
@@ -1,4 +1,4 @@
-import type { ClientCache, TClientKey, TUrl } from '../types'
+import type { ClientCache, TClientEntry, TClientKey, TUrl } from '../types'
 
 export const keyFromWs = (ws: TUrl): TClientKey => {
   return Array.isArray(ws) ? JSON.stringify(ws) : ws
@@ -8,14 +8,32 @@ export const createClientPoolHelpers = <TClient>(
   clientPool: ClientCache<TClient>,
   createClient: (ws: TUrl) => TClient | Promise<TClient>
 ) => {
+  const pendingClients = new Map<TClientKey, Promise<TClientEntry<TClient>>>()
+
   const leaseClient = async (ws: TUrl, ttlMs: number): Promise<TClient> => {
     const key = keyFromWs(ws)
     let entry = clientPool.peek(key)
 
     if (!entry) {
-      const client = await createClient(ws)
-      entry = { client, refs: 0, destroyWanted: false }
-      clientPool.set(key, entry, ttlMs)
+      let pending = pendingClients.get(key)
+      if (!pending) {
+        pending = Promise.resolve()
+          .then(() => createClient(ws))
+          .then(client => {
+            const created = { client, refs: 0, destroyWanted: false }
+            clientPool.set(key, created, ttlMs)
+            return created
+          })
+        pendingClients.set(key, pending)
+      }
+
+      try {
+        entry = await pending
+      } finally {
+        if (pendingClients.get(key) === pending) {
+          pendingClients.delete(key)
+        }
+      }
     }
 
     entry.refs += 1


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #1973

---

## 🛠️ Description of the Fix

- Bug description: Concurrent leases for an empty pool key each created and cached a separate client, leaking one client and undercounting references for the other.
- Fix summary: Share one in-flight creation promise per pool key, clear it after success or failure, and let every waiter increment the shared cache entry.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary (no public API or documented behavior changes).
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing`

---

## 🧩 Additional Notes

@michaeldev5, please review.

Verified locally with:

- `pnpm --filter @paraspell/sdk-core compile`
- `pnpm --filter @paraspell/sdk-core test:cov` (189 files, 1,253 tests; `clientPool.ts` at 100% statements/functions/lines)
- `pnpm --filter @paraspell/sdk-core lint:check`
- `pnpm --filter @paraspell/sdk-core format:check`
- `pnpm --filter @paraspell/sdk-core build`
