### PR TITLE
fix(swap): resolve native assets by id

### DIFF
--- a/packages/swap/src/assets/getExchangeAsset.test.ts
+++ b/packages/swap/src/assets/getExchangeAsset.test.ts
@@ -34,6 +34,7 @@ describe('getExchangeAsset', () => {
     symbol: 'DOT',
     decimals: 10,
     isNative: true,
+    assetId: '0',
     location: { parents: 1, interior: 'Here' },
   };
   const mockForeignAsset: TAssetInfo = {
@@ -106,6 +107,19 @@ describe('getExchangeAsset', () => {
     const result = getExchangeAsset(mockExchange, currency);
     expect(result).toEqual(mockForeignAsset);
     expect(findAssetInfoById).toHaveBeenCalled();
+  });
+
+  test('should find native asset by id', () => {
+    const currency = { id: 0 };
+    vi.mocked(findAssetInfoById).mockReturnValue(mockNativeAsset);
+
+    const result = getExchangeAsset(mockExchange, currency);
+
+    expect(result).toEqual(mockNativeAsset);
+    expect(findAssetInfoById).toHaveBeenCalledWith(
+      [mockNativeAsset, mockForeignAsset],
+      currency.id,
+    );
   });
 
   test('should return null when asset not found', () => {

--- a/packages/swap/src/assets/getExchangeAsset.ts
+++ b/packages/swap/src/assets/getExchangeAsset.ts
@@ -41,7 +41,7 @@ export const getExchangeAsset = (
 
     asset = findAssetInfoBySymbol(otherAssets, nativeAssets, currency.symbol);
   } else if ('id' in currency) {
-    asset = findAssetInfoById(otherAssets, currency.id);
+    asset = findAssetInfoById(assets, currency.id);
   } else {
     throw new RoutingResolutionError('Invalid currency input');
   }


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #1975

---

## 🛠️ Description of the Fix

- Bug description: SWAP searched ID-based inputs only among non-native exchange assets, so Hydration `{ id: 0 }` could not resolve native HDX.
- Fix summary: Pass the complete exchange asset list to `findAssetInfoById` and cover native ID lookup with a regression test.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary (no public API or documented behavior changes).
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing`

---

## 🧩 Additional Notes

@michaeldev5, please review.

Verified locally with:
- `pnpm --filter @paraspell/swap compile`
- `pnpm --filter @paraspell/swap test:cov` (59 files, 350 tests; `getExchangeAsset.ts` at 100% statements/functions/lines)
- `pnpm --filter @paraspell/swap lint:check`
- `pnpm --filter @paraspell/swap format:check`
- `pnpm --filter @paraspell/swap build`

The real Hydration registry reproduction changes from `null` to the native HDX asset.