### PR TITLE
fix(assets): reject unsupported Snowbridge origins

### DIFF
--- a/packages/assets/src/assets/getSupportedAssets.test.ts
+++ b/packages/assets/src/assets/getSupportedAssets.test.ts
@@ -95,6 +95,11 @@ describe('getSupportedAssets', () => {
     expect(result).toEqual([dotAsset, ajunAsset])
   })
 
+  it('should return no assets for unsupported snowbridge origins', () => {
+    const result = getSupportedAssets('Acala', 'Ethereum')
+    expect(result).toEqual([])
+  })
+
   it('should include native MYTH on Mythos -> Ethereum despite different locations', () => {
     const mythosNative: TAssetInfo = {
       symbol: 'MYTH',

--- a/packages/assets/src/assets/getSupportedAssets.ts
+++ b/packages/assets/src/assets/getSupportedAssets.ts
@@ -1,4 +1,9 @@
-import { isSnowbridge, isSubstrateBridge, type TChain } from '@paraspell/sdk-common'
+import {
+  ETHEREUM_BRIDGE_ORIGINS,
+  isSnowbridge,
+  isSubstrateBridge,
+  type TChain
+} from '@paraspell/sdk-common'
 
 import type { TAssetInfo, TCustomCtx } from '../types'
 import { getAssetsImpl, getNativeAssetSymbolImpl } from './assets'
@@ -11,15 +16,17 @@ export const getSupportedAssetsImpl = <TCustomChain extends string = never>(
   destination: TChain | TCustomChain,
   ctx?: TCustomCtx
 ): TAssetInfo[] => {
+  const isSubBridge = isSubstrateBridge(origin, destination)
+  const isSb = isSnowbridge(origin, destination)
+
+  if (isSb && !ETHEREUM_BRIDGE_ORIGINS.some(chain => chain === origin)) return []
+
   const originAssets = getAssetsImpl(origin, ctx)
   const destinationAssets = getAssetsImpl(destination, ctx)
 
   const supportedAssets = originAssets.filter(asset =>
     destinationAssets.some(a => isAssetEqual(a, asset))
   )
-
-  const isSubBridge = isSubstrateBridge(origin, destination)
-  const isSb = isSnowbridge(origin, destination)
 
   if (isSubBridge || isSb) {
     const systemAssets = originAssets.filter(asset => isSystemAsset(asset))


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #1977

---

## 🛠️ Description of the Fix

- Bug description: `getSupportedAssets` treated every external destination as a valid Snowbridge route, so unsupported origins such as Acala exposed DOT and ETH even though route validation rejects `Acala -> Ethereum`.
- Fix summary: Gate Snowbridge asset discovery with the existing `ETHEREUM_BRIDGE_ORIGINS` allowlist before scanning registry assets. Add regression coverage for an unsupported origin; the existing allowed AssetHub test continues to cover the supported path.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing`

> ⚠️ **Important:**
> Do **NOT** provide a centralized exchange (CEX) address (e.g., Kraken, Binance, etc.).
> Rewards sent to CEX addresses **may be lost** and are **not recoverable**.

---

## 🧩 Additional Notes

@michaeldev5, please review.

Verification completed locally:

- `pnpm --filter @paraspell/assets test` (25 files, 195 tests passed)
- `pnpm --filter @paraspell/assets compile`
- `pnpm --filter @paraspell/assets lint:check`
- `pnpm --filter @paraspell/assets format:check`
- Built-export registry check: `Acala -> Ethereum` now returns `[]`; supported `AssetHubPolkadot -> Ethereum` assets remain available
