### PR TITLE
fix(analyser): preserve object GlobalConsensus details

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -152,6 +152,24 @@ describe('convert', () => {
     expect(result).toBe('./GlobalConsensus(consensus)');
   });
 
+  it('should preserve object GlobalConsensus details in the URL', () => {
+    const location: Location = {
+      parents: 0,
+      interior: {
+        X1: {
+          GlobalConsensus: {
+            Ethereum: {
+              chainId: 1,
+            },
+          },
+        },
+      },
+    };
+
+    const result = convertLocationToUrl(location);
+    expect(result).toBe('./GlobalConsensus(Ethereum(chainId: 1))');
+  });
+
   it('convert location to URL with currency and amount location', () => {
     const location: Location = {
       parents: '0',

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -9,6 +9,25 @@ import type {
   TJunctionPlurality,
 } from '../types';
 
+const formatGlobalConsensus = (value: unknown): string => {
+  if (typeof value !== 'object' || value === null) {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(formatGlobalConsensus).join(', ');
+  }
+
+  return Object.entries(value)
+    .map(([key, nestedValue]) => {
+      const formattedValue = formatGlobalConsensus(nestedValue);
+      return typeof nestedValue === 'object' && nestedValue !== null
+        ? `${key}(${formattedValue})`
+        : `${key}: ${formattedValue}`;
+    })
+    .join(', ');
+};
+
 export const convertJunctionToReadable = (junctionOriginal: Junction): string | never => {
   const junction = Object.fromEntries(
     Object.entries(junctionOriginal).map(([k, v]) => [k.toLowerCase(), v]),
@@ -38,7 +57,7 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
     const junct = junction.plurality as TJunctionPlurality['Plurality'];
     return `Plurality(${junct.id}, ${junct.part})`;
   } else if ('globalconsensus' in junction) {
-    return `GlobalConsensus(${junction.globalconsensus})`;
+    return `GlobalConsensus(${formatGlobalConsensus(junction.globalconsensus)})`;
   }
   throw new Error('Unknown junction type');
 };


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #1978

---

## 🛠️ Description of the Fix

- Bug description: Valid object-form `GlobalConsensus` values were interpolated directly, producing `[object Object]` and losing the network and chain ID.
- Fix summary: Add a small recursive formatter that preserves nested consensus variant names and fields while leaving existing string values unchanged.
- Regression coverage: Add an Ethereum `chainId: 1` location test that expects `./GlobalConsensus(Ethereum(chainId: 1))`.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [ ] I have updated the documentation where necessary (not applicable; behavior only).
- [x] I have verified the fix does not introduce new issues in the legacy string case.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: Will provide before reward processing

> ⚠️ Do NOT use a centralized exchange (CEX) address.

---

## 🧩 Additional Notes

Verification performed locally:

- XCM Analyser TypeScript compilation succeeds.
- Object input now returns `./GlobalConsensus(Ethereum(chainId: 1))`.
- Existing string input still returns `./GlobalConsensus(consensus)`.
