### PR TITLE
fix(swap): include native assets in ID-based lookup

### DIFF
--- a/packages/swap/src/assets/getExchangeAsset.ts
+++ b/packages/swap/src/assets/getExchangeAsset.ts
@@ -41,7 +41,7 @@ export const getExchangeAsset = (
 
     asset = findAssetInfoBySymbol(otherAssets, nativeAssets, currency.symbol);
   } else if ('id' in currency) {
-    asset = findAssetInfoById(otherAssets, currency.id);
+    asset = findAssetInfoById(assets, currency.id);
   } else {
     throw new RoutingResolutionError('Invalid currency input');
   }


### PR DESCRIPTION
## Fix for #1975

### Problem
getExchangeAsset in packages/swap/src/assets/getExchangeAsset.ts passed only otherAssets (non-native) to findAssetInfoById when resolving by asset ID. This excluded native assets like Hydration HDX (assetId 0) from ID-based lookup, causing getExchangeAsset('Hydration', { id: 0 }) to return null.

### Root Cause
Line 44 used otherAssets instead of assets. PR #1549 already fixed this same omission in the general assets resolver by changing its ID lookup from otherAssets to all assets, but SWAP parallel resolver retained the old behavior.

### Fix
Changed findAssetInfoById(otherAssets, currency.id) to findAssetInfoById(assets, currency.id).

### Verification
- getExchangeAsset('Hydration', { id: 0 }) now returns the native HDX asset
- Symbol- and location-based lookups remain unaffected (they already use assets)
- No breaking changes — only adds coverage for a previously missing case

Fixes #1975