### PR TITLE
fix(sdk-core): deduplicate concurrent client leases in pool

### DIFF
--- a/packages/sdk-core/src/api/clientPool.ts
+++ b/packages/sdk-core/src/api/clientPool.ts
@@ -8,14 +8,31 @@ export const createClientPoolHelpers = <TClient>(
   clientPool: ClientCache<TClient>,
   createClient: (ws: TUrl) => TClient | Promise<TClient>
 ) => {
+  // Track in-flight client creations to prevent duplicate work on concurrent leases.
+  const inflight = new Map<TClientKey, Promise<TClient>>()
+
   const leaseClient = async (ws: TUrl, ttlMs: number): Promise<TClient> => {
     const key = keyFromWs(ws)
     let entry = clientPool.peek(key)
 
     if (!entry) {
-      const client = await createClient(ws)
-      entry = { client, refs: 0, destroyWanted: false }
-      clientPool.set(key, entry, ttlMs)
+      // If a creation is already in-flight for this key, await it instead of
+      // starting a second createClient call. This ensures both concurrent
+      // lessees receive the same client instance and refs is incremented to 2.
+      let inflightPromise = inflight.get(key)
+      if (!inflightPromise) {
+        inflightPromise = Promise.resolve(createClient(ws)).finally(() => {
+          inflight.delete(key)
+        })
+        inflight.set(key, inflightPromise)
+      }
+
+      const client = await inflightPromise
+      entry = clientPool.peek(key)
+      if (!entry) {
+        entry = { client, refs: 0, destroyWanted: false }
+        clientPool.set(key, entry, ttlMs)
+      }
     }
 
     entry.refs += 1


### PR DESCRIPTION
## Fix for #1973

### Problem
When two leaseClient calls for the same WebSocket endpoint arrive concurrently while the pool is empty, both miss the cache and independently await createClient(ws). Each stores its own entry under the same key — the second overwrites the first. The overwritten client is leaked, and refs ends at 1 despite two active lessees. Releasing one lease can then destroy the client still in use by the other.

### Root Cause
No deduplication of in-flight client creation. The check-then-create sequence at lines 13-18 is not atomic across async boundaries.

### Fix
Added an inflight Map<TClientKey, Promise<TClient>> that tracks ongoing createClient calls by pool key.

1. When a cache miss occurs, check inflight first.
2. If a creation is already running for this key, await the SAME promise — no second createClient call.
3. Store the new entry only if the pool still has no entry (the first caller may have already set it).
4. Clear the in-flight entry via .finally() so a FAILED creation does not block future retries.

### Behavior After Fix
- Promise.all([leaseClient('wss://node', 1000), leaseClient('wss://node', 1000)]) -> createClient called ONCE, both resolve to the SAME client, refs === 2.
- A rejected createClient clears the in-flight entry, so the next lease attempt retries cleanly.

Fixes #1973