### PR TITLE
fix(assets): filter unsupported Snowbridge origins in getSupportedAssets

### DIFF
--- a/packages/assets/src/assets/getSupportedAssets.ts
+++ b/packages/assets/src/assets/getSupportedAssets.ts
@@ -1,4 +1,4 @@
-import { isSnowbridge, isSubstrateBridge, type TChain } from '@paraspell/sdk-common'
+import { isSnowbridge, isSubstrateBridge, ETHEREUM_BRIDGE_ORIGINS, type TChain } from '@paraspell/sdk-common'
 
 import type { TAssetInfo, TCustomCtx } from '../types'
 import { getAssetsImpl, getNativeAssetSymbolImpl } from './assets'
@@ -32,6 +32,14 @@ export const getSupportedAssetsImpl = <TCustomChain extends string = never>(
       const stablecoinAssets = findStablecoinAssets(origin)
       return [...filteredSystemAssets, ...stablecoinAssets]
     } else {
+      // Only origins in ETHEREUM_BRIDGE_ORIGINS support Snowbridge (Ethereum)
+      // transfers. Without this check, getSupportedAssets reports assets for
+      // unsupported routes (e.g. Acala -> Ethereum), contradicting
+      // getSupportedDestinations and the transfer builder.
+      if (!ETHEREUM_BRIDGE_ORIGINS.includes(origin as never)) {
+        return []
+      }
+
       // MYTH has two valid locations (native on Mythos, ERC-20 on Ethereum),
       // so it isn't matched by isAssetEqual. Include it explicitly.
       const mythosNative =


### PR DESCRIPTION
## Fix for #1977

### Problem
getSupportedAssetsImpl entered the Snowbridge path whenever isSnowbridge returned true for the destination, without checking whether the origin chain is actually in ETHEREUM_BRIDGE_ORIGINS. This caused getSupportedAssets('Acala', 'Ethereum') to return DOT and ETH even though Acala is not a supported Snowbridge origin and the transfer builder rejects that route. This contradicts getSupportedDestinations which correctly excludes Ethereum for Acala.

### Root Cause
isSnowbridge returns true for every external destination. getSupportedAssetsImpl then enters the Snowbridge code path and returns systemAssets + supportedAssets without validating the origin against ETHEREUM_BRIDGE_ORIGINS.

### Fix
Added an early return [] when the Snowbridge path is selected but the origin is not in ETHEREUM_BRIDGE_ORIGINS. This matches route validation and getSupportedDestinations behavior.

### Verification
- getSupportedAssets('Acala', 'Ethereum') now returns []
- getSupportedAssets('AssetHubPolkadot', 'Ethereum') still returns supported assets (AssetHubPolkadot IS in ETHEREUM_BRIDGE_ORIGINS)
- getSupportedDestinations consistency restored

Fixes #1977