### PR TITLE
fix(analyser): handle object-form GlobalConsensus in convertJunctionToReadable

### DIFF
--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -38,7 +38,27 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
     const junct = junction.plurality as TJunctionPlurality['Plurality'];
     return `Plurality(${junct.id}, ${junct.part})`;
   } else if ('globalconsensus' in junction) {
-    return `GlobalConsensus(${junction.globalconsensus})`;
+    const gc = junction.globalconsensus;
+    // GlobalConsensus can be a string (e.g. 'Polkadot') or an object
+    // (e.g. { Ethereum: { chainId: 1 } }). Handle both forms to avoid
+    // [object Object] from default string coercion.
+    if (typeof gc === 'string') {
+      return `GlobalConsensus(${gc})`;
+    }
+    if (typeof gc === 'object' && gc !== null) {
+      const entries = Object.entries(gc);
+      if (entries.length > 0) {
+        const [network, fields] = entries[0];
+        if (typeof fields === 'object' && fields !== null) {
+          const fieldStr = Object.entries(fields)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ');
+          return `GlobalConsensus(${network}(${fieldStr}))`;
+        }
+        return `GlobalConsensus(${network})`;
+      }
+    }
+    return `GlobalConsensus(${String(gc)})`;
   }
   throw new Error('Unknown junction type');
 };


### PR DESCRIPTION
## Fix for #1978

### Problem
convertJunctionToReadable in packages/xcm-analyser/src/utils/utils.ts interpolated GlobalConsensus values directly into a template literal. When the value is an object (e.g. { Ethereum: { chainId: 1 } }), JavaScript default coercion produces [object Object], losing the consensus network and chain ID. This affects convertLocationToUrl, convertLocationToUrlJson, and nested results from convertXCMToUrls.

### Root Cause
The code at line 41 returns GlobalConsensus(${junction.globalconsensus}) with no type check. GlobalConsensusNetworkSchema accepts both string forms (e.g. 'Polkadot') and object forms (e.g. { Ethereum: { chainId: 1 } }), but only the string form produces correct output.

### Fix
Added type detection for GlobalConsensus values:
1. If string: return GlobalConsensus(value) (unchanged behavior)
2. If object: extract the network variant name and nested fields, return GlobalConsensus(Ethereum(chainId: 1))
3. Fallback: String() coercion for any unexpected type

### Verification
- convertLocationToUrl with { GlobalConsensus: { Ethereum: { chainId: 1 } } } now returns ./GlobalConsensus(Ethereum(chainId: 1))
- Existing string-form GlobalConsensus: 'consensus' still returns ./GlobalConsensus(consensus)
- No breaking changes to the public API

Fixes #1978