### PR TITLE
fix(analyser): accept structured account network IDs

### DIFF
--- a/packages/sdk-common/src/types/TLocation.ts
+++ b/packages/sdk-common/src/types/TLocation.ts
@@ -16,12 +16,13 @@ export type TJunctionType =
   | 'Plurality'
   | 'GlobalConsensus'
 
-type TNetworkId = string | null
 type TBodyId = string | null
 type TBodyPart = string | null
 type TStringOrNumber = string | number
 type TStringOrNumberOrBigInt = TStringOrNumber | bigint
 type THexString = string
+
+export type TNetworkId = string | null | object
 
 export type TJunctionParachain = {
   Parachain: TStringOrNumberOrBigInt | undefined
@@ -75,7 +76,7 @@ export type TJunctionPlurality = {
 }
 
 export type TJunctionGlobalConsensus = {
-  GlobalConsensus: TNetworkId | object
+  GlobalConsensus: Exclude<TNetworkId, null>
 }
 
 export type TJunction =

--- a/packages/sdk-dedot/src/XcmTransformer.test.ts
+++ b/packages/sdk-dedot/src/XcmTransformer.test.ts
@@ -62,6 +62,21 @@ describe("XcmTransformer", () => {
           value: { network: undefined, id: "0x02" },
         },
       ],
+      [
+        {
+          AccountId32: {
+            network: { Ethereum: { chainId: 1 } },
+            id: "0x03",
+          },
+        },
+        {
+          type: "AccountId32",
+          value: {
+            network: { type: "Ethereum", value: { chainId: 1 } },
+            id: "0x03",
+          },
+        },
+      ],
       [{ Id: "Alice" }, { type: "Id", value: "Alice" }],
       [{ Substrate: "Polkadot" }, { type: "Substrate", value: "Polkadot" }],
       [{ OtherReserve: "12" }, { type: "OtherReserve", value: 12 }],

--- a/packages/sdk-dedot/src/XcmTransformer.test.ts
+++ b/packages/sdk-dedot/src/XcmTransformer.test.ts
@@ -109,6 +109,21 @@ describe("XcmTransformer", () => {
         },
       ],
       [
+        {
+          AccountKey20: {
+            network: { Ethereum: { chainId: 1 } },
+            key: "0x03",
+          },
+        },
+        {
+          type: "AccountKey20",
+          value: {
+            network: { type: "Ethereum", value: { chainId: 1 } },
+            key: "0x03",
+          },
+        },
+      ],
+      [
         { SetFeesMode: { jit_withdraw: true } },
         { type: "SetFeesMode", value: { jitWithdraw: true } },
       ],

--- a/packages/sdk-dedot/src/XcmTransformer.ts
+++ b/packages/sdk-dedot/src/XcmTransformer.ts
@@ -57,7 +57,9 @@ export const transform = (obj: any): any => {
                 ? {
                     type: "Any",
                   }
-                : undefined,
+                : typeof value.network === "object" && value.network !== null
+                  ? transform(value.network)
+                  : undefined,
             id: value.id,
           },
         };
@@ -113,7 +115,9 @@ export const transform = (obj: any): any => {
                 ? {
                     type: "Any",
                   }
-                : undefined,
+                : typeof value.network === "object" && value.network !== null
+                  ? transform(value.network)
+                  : undefined,
             key: value.key,
           },
         };

--- a/packages/sdk/src/PapiXcmTransformer.test.ts
+++ b/packages/sdk/src/PapiXcmTransformer.test.ts
@@ -111,6 +111,24 @@ describe('transform', () => {
     expect(transform(input)).toEqual(expected)
   })
 
+  it('should omit an unsupported string AccountId32 network', () => {
+    const input = {
+      AccountId32: {
+        network: 'polkadot',
+        id: '0x1234abcd'
+      }
+    }
+    const expected = {
+      type: 'AccountId32',
+      value: {
+        network: undefined,
+        id: '0x1234abcd'
+      }
+    }
+
+    expect(transform(input)).toEqual(expected)
+  })
+
   it('should transform Id correctly', () => {
     const input = {
       Id: {

--- a/packages/sdk/src/PapiXcmTransformer.test.ts
+++ b/packages/sdk/src/PapiXcmTransformer.test.ts
@@ -84,6 +84,33 @@ describe('transform', () => {
     expect(transform(input)).toEqual(expected)
   })
 
+  it('should preserve a structured AccountId32 network', () => {
+    const input = {
+      AccountId32: {
+        network: {
+          Ethereum: {
+            chainId: 1
+          }
+        },
+        id: '0x1234abcd'
+      }
+    }
+    const expected = {
+      type: 'AccountId32',
+      value: {
+        network: {
+          type: 'Ethereum',
+          value: {
+            chain_id: 1n
+          }
+        },
+        id: '0x1234abcd'
+      }
+    }
+
+    expect(transform(input)).toEqual(expected)
+  })
+
   it('should transform Id correctly', () => {
     const input = {
       Id: {

--- a/packages/sdk/src/PapiXcmTransformer.test.ts
+++ b/packages/sdk/src/PapiXcmTransformer.test.ts
@@ -210,6 +210,33 @@ describe('transform', () => {
     expect(transform(input)).toEqual(expected)
   })
 
+  it('should preserve a structured AccountKey20 network', () => {
+    const input = {
+      AccountKey20: {
+        network: {
+          Ethereum: {
+            chainId: 1
+          }
+        },
+        key: '0xabcdef1234567890'
+      }
+    }
+    const expected = {
+      type: 'AccountKey20',
+      value: {
+        network: {
+          type: 'Ethereum',
+          value: {
+            chain_id: 1n
+          }
+        },
+        key: '0xabcdef1234567890'
+      }
+    }
+
+    expect(transform(input)).toEqual(expected)
+  })
+
   it('should transfer GlobalConsensus', () => {
     const input = {
       GlobalConsensus: {

--- a/packages/sdk/src/PapiXcmTransformer.ts
+++ b/packages/sdk/src/PapiXcmTransformer.ts
@@ -45,7 +45,9 @@ export const transform = (obj: any): any => {
                 ? {
                     type: 'Any'
                   }
-                : undefined,
+                : typeof value.network === 'object' && value.network !== null
+                  ? transform(value.network)
+                  : undefined,
             id: value.id
           }
         }
@@ -101,7 +103,9 @@ export const transform = (obj: any): any => {
                 ? {
                     type: 'Any'
                   }
-                : undefined,
+                : typeof value.network === 'object' && value.network !== null
+                  ? transform(value.network)
+                  : undefined,
             key: value.key
           }
         }

--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -74,6 +74,27 @@ describe('convert', () => {
     expect(result).toBe('./AccountId32(null, 0x123)');
   });
 
+  it('preserves an object-form network ID in an account junction', () => {
+    const location: Location = {
+      parents: 0,
+      interior: {
+        X1: {
+          AccountId32: {
+            network: {
+              Ethereum: {
+                chainId: 1,
+              },
+            },
+            id: '0x1234',
+          },
+        },
+      },
+    };
+
+    const result = convertLocationToUrl(location);
+    expect(result).toBe('./AccountId32(Ethereum(chainId: 1), 0x1234)');
+  });
+
   it('should convert location to URL with AccountIndex64 interior', () => {
     const location: Location = {
       parents: '0',

--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -385,6 +385,24 @@ describe('InteriorSchema', () => {
   });
 
   describe('HexString validation in Junctions', () => {
+    it('account junctions should accept object-form network IDs', () => {
+      const accountId32 = JunctionAccountId32.safeParse({
+        AccountId32: {
+          network: { Ethereum: { chainId: 1 } },
+          id: '0x1234',
+        },
+      });
+      const accountKey20 = JunctionAccountKey20.safeParse({
+        AccountKey20: {
+          network: { ByGenesis: `0x${'11'.repeat(32)}` },
+          key: `0x${'22'.repeat(20)}`,
+        },
+      });
+
+      expect(accountId32.success).toBe(true);
+      expect(accountKey20.success).toBe(true);
+    });
+
     it('JunctionAccountId32 should pass for valid hex id', () => {
       const data = {
         AccountId32: {

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -24,7 +24,15 @@ export const GlobalConsensusNetworkSchema = z.union([
       chainId: z.number(),
     }),
   }),
-  z.record(z.string(), z.any()),
+  z.object({
+    ByGenesis: HexString,
+  }),
+  z.object({
+    ByFork: z.object({
+      blockNumber: StringOrNumberOrBigInt,
+      blockHash: HexString,
+    }),
+  }),
   z.string(),
 ]);
 

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-const NetworkId = z.string().nullable();
 const BodyId = z.string().nullable();
 const BodyPart = z.string().nullable();
 const StringOrNumber = z.union(
@@ -18,6 +17,18 @@ const HexString = z.string().regex(/^0x[0-9a-fA-F]+$/, {
   message:
     "Invalid hex string format. Must start with '0x' and be followed by one or more hex characters (0-9, a-f, A-F).",
 });
+
+export const GlobalConsensusNetworkSchema = z.union([
+  z.object({
+    Ethereum: z.object({
+      chainId: z.number(),
+    }),
+  }),
+  z.record(z.string(), z.any()),
+  z.string(),
+]);
+
+const NetworkId = GlobalConsensusNetworkSchema.nullable();
 
 export const JunctionParachain = z.object({ Parachain: StringOrNumberOrBigInt });
 
@@ -46,16 +57,6 @@ export const JunctionOnlyChild = z.object({ OnlyChild: z.string() });
 export const JunctionPlurality = z.object({
   Plurality: z.object({ id: BodyId, part: BodyPart }),
 });
-
-export const GlobalConsensusNetworkSchema = z.union([
-  z.object({
-    Ethereum: z.object({
-      chainId: z.number(),
-    }),
-  }),
-  z.record(z.string(), z.any()),
-  z.string(),
-]);
 
 export const JunctionGlobalConsensus = z.object({ GlobalConsensus: GlobalConsensusNetworkSchema });
 

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -14,10 +14,6 @@ const formatNetworkId = (value: unknown): string => {
     return String(value);
   }
 
-  if (Array.isArray(value)) {
-    return value.map(formatNetworkId).join(', ');
-  }
-
   return Object.entries(value)
     .map(([key, nestedValue]) => {
       const formattedValue = formatNetworkId(nestedValue);

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -9,6 +9,25 @@ import type {
   TJunctionPlurality,
 } from '../types';
 
+const formatNetworkId = (value: unknown): string => {
+  if (typeof value !== 'object' || value === null) {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(formatNetworkId).join(', ');
+  }
+
+  return Object.entries(value)
+    .map(([key, nestedValue]) => {
+      const formattedValue = formatNetworkId(nestedValue);
+      return typeof nestedValue === 'object' && nestedValue !== null
+        ? `${key}(${formattedValue})`
+        : `${key}: ${formattedValue}`;
+    })
+    .join(', ');
+};
+
 export const convertJunctionToReadable = (junctionOriginal: Junction): string | never => {
   const junction = Object.fromEntries(
     Object.entries(junctionOriginal).map(([k, v]) => [k.toLowerCase(), v]),
@@ -18,13 +37,13 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
     return `Parachain(${junction.parachain})`;
   } else if ('accountid32' in junction) {
     const junct = junction.accountid32 as TJunctionAccountId32['AccountId32'];
-    return `AccountId32(${junct.network}, ${junct.id})`;
+    return `AccountId32(${formatNetworkId(junct.network)}, ${junct.id})`;
   } else if ('accountindex64' in junction) {
     const junct = junction.accountindex64 as TJunctionAccountIndex64['AccountIndex64'];
-    return `AccountIndex64(${junct.network}, ${junct.index})`;
+    return `AccountIndex64(${formatNetworkId(junct.network)}, ${junct.index})`;
   } else if ('accountkey20' in junction) {
     const junct = junction.accountkey20 as TJunctionAccountKey20['AccountKey20'];
-    return `AccountKey20(${junct.network}, ${junct.key})`;
+    return `AccountKey20(${formatNetworkId(junct.network)}, ${junct.key})`;
   } else if ('palletinstance' in junction) {
     return `PalletInstance(${junction.palletinstance})`;
   } else if ('generalindex' in junction) {


### PR DESCRIPTION
# ?? Bug Fix Pull Request

## ?? Related Issue

Closes #1985

---

## ??? Description of the Fix

- Bug description: valid structured XCM `NetworkId` values in `AccountId32`, `AccountIndex64`, and `AccountKey20` were rejected by the analyser because their `network` schema only accepted strings or `null`.
- Fix summary:
  - accept the structured `Ethereum`, `ByGenesis`, and `ByFork` variants supported by XCM;
  - format nested network variants without producing `[object Object]`;
  - align the shared SDK location type with structured network IDs;
  - preserve structured account networks in both PAPI and Dedot transformers;
  - cover schema validation, URL conversion, and both SDK transformer shapes with regression tests.

---

## ? Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation remains accurate.
- [x] I have verified the fix does not introduce new issues in the changed packages.

Validation completed locally:

- `@paraspell/xcm-analyser` runAll - 84/84 tests passed
- `@paraspell/sdk-common` compile and lint - passed; 525/525 tests passed
- PAPI transformer regression suite - 45/45 tests passed
- Dedot transformer regression suite - 36/36 tests passed
- `@paraspell/sdk-core` compile - passed
- `git diff --check` - passed

The initial CI run exposed the cross-package SDK type mismatch; commit `3c59983` fixed it. Commits `5db52d3` and `baf03d7` cover the structured and fallback account-network branches and remove an unreachable formatter branch flagged by Codecov. The new CI run is the final Linux monorepo validation.

---

## ?? Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing`

---

## ?? Additional Notes

@michaeldev5, could you please review this updated bug-bounty fix?