### PR TITLE
fix(analyser): return all nested XCM locations

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -260,6 +260,43 @@ describe('convert', () => {
     ]);
   });
 
+  it('converts every location nested in one tx argument', () => {
+    const xcmCallArguments = [
+      {
+        assets: [
+          {
+            id: {
+              Concrete: {
+                parents: '1',
+                interior: {
+                  X1: {
+                    Parachain: '2000',
+                  },
+                },
+              },
+            },
+          },
+          {
+            id: {
+              Concrete: {
+                parents: '0',
+                interior: {
+                  X1: {
+                    PalletInstance: '50',
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = convertXCMToUrls(xcmCallArguments);
+
+    expect(result).toStrictEqual(['../Parachain(2000)', './PalletInstance(50)']);
+  });
+
   it('convert location to URL from tx arguments with no locations', () => {
     const xcmCallArguments = [
       '1', // currency_id for KSM

--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { ZodError } from 'zod';
 
-import { type Location } from '../types';
+import { type Junction, type Location } from '../types';
+import { convertJunctionToReadable } from '../utils/utils';
 import { convertLocationToUrl, convertXCMToUrls } from './convert';
 
 describe('convert', () => {
+  it('rejects an unknown junction passed directly to the formatter', () => {
+    const unknownJunction = { Unknown: 1 } as unknown as Junction;
+
+    expect(() => convertJunctionToReadable(unknownJunction)).toThrow('Unknown junction type');
+  });
+
   it('convert location to URL', () => {
     const location: Location = {
       parents: '0',
@@ -302,6 +309,7 @@ describe('convert', () => {
       '1', // currency_id for KSM
       '100000000000', // amount - 0.1 KSM
       'Unlimited', // dest_weight_limit
+      null,
     ];
 
     const result = convertXCMToUrls(xcmCallArguments);

--- a/packages/xcm-analyser/src/converter/convert.ts
+++ b/packages/xcm-analyser/src/converter/convert.ts
@@ -1,6 +1,6 @@
 import { LocationSchema } from '../schema';
 import type { Junction, JunctionType, Location } from '../types';
-import { convertJunctionToReadable, findLocationInObject } from '../utils/utils';
+import { convertJunctionToReadable, findLocationsInObject } from '../utils/utils';
 
 /**
  * Converts a XCM location JSON string into its URL representation.
@@ -48,12 +48,5 @@ export const convertLocationToUrl = (args: unknown): string => {
  * @returns An array of URL representations for each found location.
  */
 export const convertXCMToUrls = (args: unknown[]): string[] => {
-  return args.flatMap((arg) => {
-    const location = findLocationInObject(arg);
-    if (location !== null && location !== undefined) {
-      return [convertLocationToUrl(location)];
-    } else {
-      return [];
-    }
-  });
+  return args.flatMap((arg) => findLocationsInObject(arg).map(convertLocationToUrl));
 };

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -44,6 +44,12 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
 };
 
 export function findLocationInObject(obj: unknown): Location | null {
+  return findLocationsInObject(obj)[0] ?? null;
+}
+
+export function findLocationsInObject(obj: unknown): Location[] {
+  const locations: Location[] = [];
+
   function hasSpecificKeys(value: unknown): boolean {
     return (
       typeof value === 'object' &&
@@ -54,17 +60,16 @@ export function findLocationInObject(obj: unknown): Location | null {
     );
   }
 
-  function searchObject(value: unknown): Location | null {
+  function searchObject(value: unknown): void {
     if (hasSpecificKeys(value)) {
-      return LocationSchema.parse(value);
+      locations.push(LocationSchema.parse(value));
     } else if (typeof value === 'object' && value !== null) {
       for (const key of Object.keys(value)) {
-        const result = searchObject((value as Record<string, unknown>)[key]);
-        if (result) return result;
+        searchObject((value as Record<string, unknown>)[key]);
       }
     }
-    return null;
   }
 
-  return searchObject(obj);
+  searchObject(obj);
+  return locations;
 }

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -43,10 +43,6 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
   throw new Error('Unknown junction type');
 };
 
-export function findLocationInObject(obj: unknown): Location | null {
-  return findLocationsInObject(obj)[0] ?? null;
-}
-
 export function findLocationsInObject(obj: unknown): Location[] {
   const locations: Location[] = [];
 


### PR DESCRIPTION
# ?? Bug Fix Pull Request

## ?? Related Issue

Closes #1987

---

## ??? Description of the Fix

- Bug description: `convertXCMToUrls` returned only the first location inside each top-level argument, silently dropping valid sibling locations.
- Root cause: the recursive search stopped as soon as it found one matching object.
- Fix summary: replace the single-result search with a complete collector, preserve deterministic object/array traversal order, and convert every discovered location.

---

## ? Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation remains accurate: the implementation now matches "each found location."
- [x] I have verified the fix does not introduce new issues.

Validation completed locally:

- `pnpm --filter @paraspell/xcm-analyser run runAll` - 84/84 tests passed
- `pnpm --filter @paraspell/xcm-analyser run build` - passed
- `git diff --check` - passed

The first Linux CI run passed. Commits `4d6a832` and `0789c46` remove the obsolete helper and exercise the remaining traversal/formatter branches; local coverage now reports 100% for `utils.ts`.

---

## ?? Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing`

---

## ?? Additional Notes

@michaeldev5, could you please review this bug-bounty fix?