### PR TITLE
fix(analyser): validate location parent counts

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -43,6 +43,19 @@ describe('convert', () => {
     expect(result).toBe('../../../PalletInstance(50)/GeneralIndex(41)');
   });
 
+  it.each([-1, 1.5, 256])('rejects invalid parent count %s', (parents) => {
+    expect(() =>
+      convertLocationToUrl({
+        parents,
+        interior: {
+          X1: {
+            Parachain: 2006,
+          },
+        },
+      }),
+    ).toThrow(ZodError);
+  });
+
   it('convert location to URL with parachain interior', () => {
     const location: Location = {
       parents: '1',

--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -447,12 +447,12 @@ describe('LocationSchema', () => {
     }
   });
 
-  it('should pass with valid parents (string with comma) and Interior { Here: null }', () => {
-    const data = { parents: '1,000', interior: { Here: null } };
+  it('should pass with valid string parents and Interior { Here: null }', () => {
+    const data = { parents: '255', interior: { Here: null } };
     const result = LocationSchema.safeParse(data);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({ parents: '1000', interior: { Here: null } });
+      expect(result.data).toEqual({ parents: '255', interior: { Here: null } });
     }
   });
 
@@ -474,6 +474,19 @@ describe('LocationSchema', () => {
   it('should fail if parents is invalid', () => {
     const data = { parents: 'abc', interior: 'Here' };
     const result = LocationSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it.each([-1, 1.5, 256, Number.MAX_SAFE_INTEGER])(
+    'should reject out-of-range numeric parents: %s',
+    (parents) => {
+      const result = LocationSchema.safeParse({ parents, interior: 'Here' });
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it.each(['256', '1,000'])('should reject out-of-range string parents: %s', (parents) => {
+    const result = LocationSchema.safeParse({ parents, interior: 'Here' });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -13,6 +13,13 @@ const StringOrNumber = z.union(
   ],
   { error: 'Expected a number or numeric string' },
 );
+const U8StringOrNumber = StringOrNumber.refine(
+  (value) => {
+    const number = Number(value);
+    return Number.isInteger(number) && number >= 0 && number <= 255;
+  },
+  { error: 'Expected an unsigned 8-bit integer (0-255)' },
+);
 const StringOrNumberOrBigInt = StringOrNumber.or(z.bigint());
 const HexString = z.string().regex(/^0x[0-9a-fA-F]+$/, {
   message:
@@ -134,6 +141,6 @@ export const InteriorSchema = z.union(
 );
 
 export const LocationSchema = z.object({
-  parents: StringOrNumber,
+  parents: U8StringOrNumber,
   interior: InteriorSchema,
 });


### PR DESCRIPTION
# Bug Fix Pull Request

## Related Issue

Closes #1991

---

## Description of the Fix

- Bug description: `LocationSchema` accepted negative, fractional, and greater-than-255 `parents` values even though the canonical XCM `Location.parents` field is `u8`. The converter then silently produced paths that did not represent the input XCM value, or could throw for a sufficiently large count.
- Fix summary: Refine the existing number-or-numeric-string schema for `parents` so only integers in the inclusive `0..=255` range are accepted. Preserve the existing accepted input/output representation for valid numeric strings.
- Regression coverage: Add schema cases for numeric and string values outside the range, integration cases through `convertLocationToUrl`, and keep the maximum valid value (`255`) covered.

---

## Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation changes are not required; this aligns validation with the documented XCM type.
- [x] I have verified the fix does not introduce new issues.

---

## Validation

- `pnpm --filter @paraspell/xcm-analyser runAll` - 91/91 tests pass; compile, format, and lint pass.
- `pnpm --filter @paraspell/xcm-analyser build` - pass.
- `pnpm --filter @paraspell/xcm-analyser test:cov` - 91/91 tests pass.
- `git diff --check` - pass.

Canonical type reference: https://paritytech.github.io/polkadot-sdk/master/staging_xcm/v4/struct.Location.html

---

## Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing.`

The final address will be a non-CEX Polkadot Asset Hub address and will be supplied before any reward is processed.

---

## Additional Notes

@michaeldev5, could you please review this bug-bounty fix? The report includes the baseline reproduction, impact, duplicate search, and canonical type reference.