### PR TITLE
fix(analyser): support OnlyChild unit junctions

### DIFF
--- a/packages/sdk-common/src/types/TLocation.ts
+++ b/packages/sdk-common/src/types/TLocation.ts
@@ -64,7 +64,7 @@ export type TJunctionGeneralKey = {
 }
 
 export type TJunctionOnlyChild = {
-  OnlyChild: string
+  OnlyChild: string | null
 }
 
 export type TJunctionPlurality = {

--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -138,6 +138,17 @@ describe('convert', () => {
     expect(result).toBe('./OnlyChild(child)');
   });
 
+  it('should convert a null-valued OnlyChild unit variant', () => {
+    const result = convertLocationToUrl({
+      parents: 0,
+      interior: {
+        X1: [{ OnlyChild: null }],
+      },
+    });
+
+    expect(result).toBe('./OnlyChild');
+  });
+
   it('should convert location to URL with GlobalConsensus interior', () => {
     const location: Location = {
       parents: '0',

--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -41,7 +41,7 @@ const mockGeneralIndex: TJunctionGeneralIndex = { GeneralIndex: BigInt(100) };
 const mockGeneralKey: TJunctionGeneralKey = {
   GeneralKey: { length: 32, data: '0xaabbccddeeff' },
 };
-const mockOnlyChild: TJunctionOnlyChild = { OnlyChild: '' };
+const mockOnlyChild: TJunctionOnlyChild = { OnlyChild: null };
 const mockPlurality: TJunctionPlurality = {
   Plurality: { id: 'Executive', part: 'Fellowship' },
 };
@@ -381,6 +381,15 @@ describe('InteriorSchema', () => {
       const data = { PalletInstance: 'abc' };
       const result = JunctionPalletInstance.safeParse(data);
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OnlyChild validation in Junctions', () => {
+    it('JunctionOnlyChild should accept the null payload emitted for the unit variant', () => {
+      const data = { OnlyChild: null };
+      const result = InteriorSchema.safeParse({ X1: [data] });
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -41,7 +41,7 @@ export const JunctionGeneralKey = z.object({
   GeneralKey: z.object({ length: StringOrNumberOrBigInt, data: HexString }),
 });
 
-export const JunctionOnlyChild = z.object({ OnlyChild: z.string() });
+export const JunctionOnlyChild = z.object({ OnlyChild: z.string().nullable() });
 
 export const JunctionPlurality = z.object({
   Plurality: z.object({ id: BodyId, part: BodyPart }),

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -33,6 +33,9 @@ export const convertJunctionToReadable = (junctionOriginal: Junction): string | 
     const junct = junction.generalkey as TJunctionGeneralKey['GeneralKey'];
     return `GeneralKey(${junct.length}, ${junct.data})`;
   } else if ('onlychild' in junction) {
+    if (junction.onlychild === null) {
+      return 'OnlyChild';
+    }
     return `OnlyChild(${junction.onlychild})`;
   } else if ('plurality' in junction) {
     const junct = junction.plurality as TJunctionPlurality['Plurality'];


### PR DESCRIPTION
# ?? Bug Fix Pull Request

## ?? Related Issue

Closes #1993

---

## ??? Description of the Fix

- Bug description: XCM Analyser required a string payload for `OnlyChild`, so it rejected the valid `{ OnlyChild: null }` representation emitted by ParaSpell's own PAPI location normalization path.
- Fix summary: accept both canonical null unit payloads and legacy string payloads, and render the null-valued unit junction as `OnlyChild` without inventing an argument.
- Compatibility: existing string-valued inputs keep their previous `OnlyChild(value)` output.

---

## ? Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation does not require changes; the documented supported junction remains `OnlyChild`.
- [x] I have verified the fix does not introduce new issues.

Validation completed locally:

- `pnpm --filter @paraspell/xcm-analyser runAll` - 84/84 tests passed
- `pnpm --filter @paraspell/xcm-analyser build` - passed
- `pnpm --filter @paraspell/xcm-analyser test:cov` - 84/84 tests passed; 94.31% statements and 93.87% branches
- `git diff --check` - passed

---

## ?? Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing.`

---

## ?? Additional Notes

The Polkadot SDK models `OnlyChild` as a unit variant, and `packages/swap/src/exchanges/AssetHub/utils/papiLocationToJson.test.ts` already asserts that the PAPI normalizer emits `{ OnlyChild: null }`.

@michaeldev5