### PR TITLE
fix(analyser): validate numeric junction bounds

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -176,6 +176,25 @@ describe('convert', () => {
     expect(result).toBe('./PalletInstance(50)/GeneralIndex(1984)');
   });
 
+  it.each([
+    { Parachain: -1 },
+    { Parachain: '4294967296' },
+    { AccountIndex64: { network: null, index: '18446744073709551616' } },
+    { AccountIndex64: { network: null, index: Number.MAX_SAFE_INTEGER + 1 } },
+    { PalletInstance: 1.5 },
+    { PalletInstance: 256 },
+    { GeneralIndex: BigInt(-1) },
+    { GeneralIndex: BigInt('340282366920938463463374607431768211456') },
+    { GeneralKey: { length: 256, data: '0x00' } },
+  ])('rejects an out-of-range numeric junction: %o', (junction) => {
+    expect(() =>
+      convertLocationToUrl({
+        parents: 0,
+        interior: { X1: junction },
+      }),
+    ).toThrow(ZodError);
+  });
+
   it('convert location to URL from tx arguments with one location', () => {
     const xcmCallArguments = [
       '1', // currency_id for KSM

--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -321,12 +321,12 @@ describe('InteriorSchema', () => {
       }
     });
 
-    it('JunctionParachain should correctly parse BigInt', () => {
-      const data = { Parachain: BigInt(1234567890123) };
+    it('JunctionParachain should correctly parse an in-range BigInt', () => {
+      const data = { Parachain: BigInt(4294967295) };
       const result = JunctionParachain.safeParse(data);
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.Parachain).toBe(BigInt(1234567890123));
+        expect(result.data.Parachain).toBe(BigInt(4294967295));
       }
     });
 
@@ -381,6 +381,44 @@ describe('InteriorSchema', () => {
       const data = { PalletInstance: 'abc' };
       const result = JunctionPalletInstance.safeParse(data);
       expect(result.success).toBe(false);
+    });
+
+    it.each([
+      ['negative Parachain', { Parachain: -1 }],
+      ['Parachain above u32', { Parachain: '4294967296' }],
+      [
+        'AccountIndex64 above u64',
+        { AccountIndex64: { network: null, index: '18446744073709551616' } },
+      ],
+      [
+        'unsafe AccountIndex64 number',
+        { AccountIndex64: { network: null, index: Number.MAX_SAFE_INTEGER + 1 } },
+      ],
+      ['fractional PalletInstance', { PalletInstance: 1.5 }],
+      ['PalletInstance above u8', { PalletInstance: 256 }],
+      ['negative GeneralIndex', { GeneralIndex: BigInt(-1) }],
+      [
+        'GeneralIndex above u128',
+        { GeneralIndex: BigInt('340282366920938463463374607431768211456') },
+      ],
+      ['GeneralKey length above u8', { GeneralKey: { length: 256, data: '0x00' } }],
+    ])('should reject %s', (_name, junction) => {
+      const result = InteriorSchema.safeParse({ X1: junction });
+      expect(result.success).toBe(false);
+    });
+
+    it.each([
+      ['maximum Parachain', { Parachain: '4294967295' }],
+      [
+        'maximum AccountIndex64',
+        { AccountIndex64: { network: null, index: BigInt('18446744073709551615') } },
+      ],
+      ['maximum PalletInstance', { PalletInstance: 255 }],
+      ['maximum GeneralIndex', { GeneralIndex: '340282366920938463463374607431768211455' }],
+      ['maximum GeneralKey length', { GeneralKey: { length: 255, data: '0x00' } }],
+    ])('should accept %s', (_name, junction) => {
+      const result = InteriorSchema.safeParse({ X1: junction });
+      expect(result.success).toBe(true);
     });
   });
 

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -14,31 +14,50 @@ const StringOrNumber = z.union(
   { error: 'Expected a number or numeric string' },
 );
 const StringOrNumberOrBigInt = StringOrNumber.or(z.bigint());
+const boundedUnsignedInteger = (max: bigint, bits: number) =>
+  StringOrNumberOrBigInt.refine(
+    (value) => {
+      if (typeof value === 'number') {
+        return Number.isSafeInteger(value) && value >= 0 && BigInt(value) <= max;
+      }
+
+      const integer = typeof value === 'bigint' ? value : BigInt(value);
+      return integer >= BigInt(0) && integer <= max;
+    },
+    { error: `Expected an unsigned ${bits}-bit integer` },
+  );
+const U8StringOrNumberOrBigInt = boundedUnsignedInteger(BigInt('255'), 8);
+const U32StringOrNumberOrBigInt = boundedUnsignedInteger(BigInt('4294967295'), 32);
+const U64StringOrNumberOrBigInt = boundedUnsignedInteger(BigInt('18446744073709551615'), 64);
+const U128StringOrNumberOrBigInt = boundedUnsignedInteger(
+  BigInt('340282366920938463463374607431768211455'),
+  128,
+);
 const HexString = z.string().regex(/^0x[0-9a-fA-F]+$/, {
   message:
     "Invalid hex string format. Must start with '0x' and be followed by one or more hex characters (0-9, a-f, A-F).",
 });
 
-export const JunctionParachain = z.object({ Parachain: StringOrNumberOrBigInt });
+export const JunctionParachain = z.object({ Parachain: U32StringOrNumberOrBigInt });
 
 export const JunctionAccountId32 = z.object({
   AccountId32: z.object({ network: NetworkId, id: HexString }),
 });
 
 export const JunctionAccountIndex64 = z.object({
-  AccountIndex64: z.object({ network: NetworkId, index: StringOrNumberOrBigInt }),
+  AccountIndex64: z.object({ network: NetworkId, index: U64StringOrNumberOrBigInt }),
 });
 
 export const JunctionAccountKey20 = z.object({
   AccountKey20: z.object({ network: NetworkId, key: HexString }),
 });
 
-export const JunctionPalletInstance = z.object({ PalletInstance: StringOrNumberOrBigInt });
+export const JunctionPalletInstance = z.object({ PalletInstance: U8StringOrNumberOrBigInt });
 
-export const JunctionGeneralIndex = z.object({ GeneralIndex: StringOrNumberOrBigInt });
+export const JunctionGeneralIndex = z.object({ GeneralIndex: U128StringOrNumberOrBigInt });
 
 export const JunctionGeneralKey = z.object({
-  GeneralKey: z.object({ length: StringOrNumberOrBigInt, data: HexString }),
+  GeneralKey: z.object({ length: U8StringOrNumberOrBigInt, data: HexString }),
 });
 
 export const JunctionOnlyChild = z.object({ OnlyChild: z.string() });


### PR DESCRIPTION
# ?? Bug Fix Pull Request

## ?? Related Issue

Closes #1995

---

## ??? Description of the Fix

- Bug description: the analyser used one unbounded numeric schema for `Parachain`, `AccountIndex64`, `PalletInstance`, `GeneralIndex`, and `GeneralKey.length`, accepting values that cannot exist in their XCM `u32`, `u64`, `u8`, `u128`, and `u8` fields.
- Fix summary: add reusable bounded unsigned-integer refinements and apply the correct width to each junction field.
- Precision: JavaScript numbers must be safe non-negative integers; exact larger u64/u128 values remain accepted as decimal strings or `bigint`.
- Compatibility: in-range numbers, bigints, plain decimal strings, and existing comma-delimited decimal strings preserve their original output representation.

---

## ? Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation does not require changes.
- [x] I have verified the fix does not introduce new issues.

Validation completed locally:

- Baseline before the fix: 82/82 tests passed while all reproduced invalid values were accepted
- Regression before the fix: 16/16 invalid-value expectations failed
- `pnpm --filter @paraspell/xcm-analyser runAll` - passed
- `pnpm --filter @paraspell/xcm-analyser build` - passed
- `pnpm --filter @paraspell/xcm-analyser test:cov` - 105/105 tests passed; 94.79% statements and 94.64% branches
- `git diff --check` - passed

---

## ?? Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `Will provide before reward processing.`

---

## ?? Additional Notes

The bounds follow the official Polkadot SDK `Junction` definition. This change does not overlap #1991, which validates the separate `Location.parents` field.

@michaeldev5