### PR TITLE
fix: XCM analyser schema validation - issue #1991

### DIFF
--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -477,3 +477,23 @@ describe('LocationSchema', () => {
     expect(result.success).toBe(false);
   });
 });
+
+
+describe('LocationSchema parents u8 validation (Issue #1991)', () => {
+  it('accepts valid u8 parent counts', () => {
+    expect(LocationSchema.safeParse({ parents: 0, interior: 'Here' }).success).toBe(true);
+    expect(LocationSchema.safeParse({ parents: 255, interior: 'Here' }).success).toBe(true);
+    expect(LocationSchema.safeParse({ parents: 1, interior: { X1: { Parachain: 1000 } } }).success).toBe(true);
+    expect(LocationSchema.safeParse({ parents: '128', interior: 'Here' }).success).toBe(true);
+  });
+  it('rejects parents > 255', () => {
+    expect(LocationSchema.safeParse({ parents: 256, interior: 'Here' }).success).toBe(false);
+    expect(LocationSchema.safeParse({ parents: 1000, interior: 'Here' }).success).toBe(false);
+  });
+  it('rejects negative parents', () => {
+    expect(LocationSchema.safeParse({ parents: -1, interior: 'Here' }).success).toBe(false);
+  });
+  it('rejects non-integer parents', () => {
+    expect(LocationSchema.safeParse({ parents: 1.5, interior: 'Here' }).success).toBe(false);
+  });
+});

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -134,6 +134,12 @@ export const InteriorSchema = z.union(
 );
 
 export const LocationSchema = z.object({
-  parents: StringOrNumber,
+  parents: StringOrNumber.refine(
+    (val) => {
+      const n = Number(val);
+      return Number.isSafeInteger(n) && n >= 0 && n <= 255;
+    },
+    { message: 'parents must be a u8 integer (0 to 255)' },
+  ),
   interior: InteriorSchema,
 });


### PR DESCRIPTION
## Fixes

Closes #1991

### LocationSchema Parents u8 Validation

The `parents` field in XCM `MultiLocation` is defined as a u8 (0–255). Previously unconstrained.

**Change:** Added `.refine()` enforcing 0 ≤ parents ≤ 255, rejecting negatives, overflow, and non-integers.

## Tests

Added comprehensive tests for edge cases and range validation.

## CI

Added GitHub Actions CI workflow (Node 24, pnpm).

```bash
pnpm install
pnpm --filter @paraspell/xcm-analyser test
```
