### PR TITLE
fix(xcm-api): reject malformed amount strings

### DIFF
--- a/apps/xcm-api/src/utils/validateAmount.test.ts
+++ b/apps/xcm-api/src/utils/validateAmount.test.ts
@@ -7,10 +7,35 @@ describe('validateAmount', () => {
     expect(validateAmount('100')).toBe(true);
     expect(validateAmount('0.5')).toBe(true);
     expect(validateAmount('1234.567')).toBe(true);
+    expect(validateAmount('.5')).toBe(true);
+    expect(validateAmount('+1')).toBe(true);
+    expect(validateAmount('1e3')).toBe(true);
+    expect(validateAmount('1e-3')).toBe(true);
+    expect(validateAmount(' 0.5 ')).toBe(true);
   });
 
   it('should return false for negative numbers', () => {
     expect(validateAmount('-100')).toBe(false);
     expect(validateAmount('-0.5')).toBe(false);
+  });
+
+  it('should reject malformed numeric strings instead of accepting a numeric prefix', () => {
+    expect(validateAmount('1abc')).toBe(false);
+    expect(validateAmount('1.2.3')).toBe(false);
+    expect(validateAmount('1e')).toBe(false);
+  });
+
+  it('should reject non-finite and overflowed values', () => {
+    expect(validateAmount('Infinity')).toBe(false);
+    expect(validateAmount('-Infinity')).toBe(false);
+    expect(validateAmount('NaN')).toBe(false);
+    expect(validateAmount('1e309')).toBe(false);
+  });
+
+  it('should reject empty and non-positive values', () => {
+    expect(validateAmount('')).toBe(false);
+    expect(validateAmount('   ')).toBe(false);
+    expect(validateAmount('0')).toBe(false);
+    expect(validateAmount('-0')).toBe(false);
   });
 });

--- a/apps/xcm-api/src/utils/validateAmount.ts
+++ b/apps/xcm-api/src/utils/validateAmount.ts
@@ -1,4 +1,10 @@
+const DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 export const validateAmount = (val: string) => {
-  const num = parseFloat(val);
-  return !isNaN(num) && num > 0;
+  const normalized = val.trim();
+
+  if (!DECIMAL_PATTERN.test(normalized)) return false;
+
+  const num = Number(normalized);
+  return Number.isFinite(num) && num > 0;
 };


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2000

---

## 🛠️ Description of the Fix

- Bug description: the XCM API used `parseFloat` as a boolean validator, so numeric prefixes (`1abc`, `1.2.3`), explicit non-finite values, and overflowed exponentials passed the shared amount schema.
- Fix summary: validate the entire trimmed decimal/scientific-notation string, convert with `Number`, and require a finite value greater than zero.
- Compatibility: valid positive integers, decimals, leading-dot decimals, leading plus signs, surrounding whitespace, and finite scientific notation remain accepted.
- Regression coverage: malformed suffixes, incomplete exponents, `NaN`, infinities, overflow, empty input, zero, and negative values.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation changes are not required for this validation-only fix.
- [x] I have verified the focused fix does not introduce new issues.

Validation performed:

```text
pnpm --filter @paraspell/xcm-api exec vitest run src/utils/validateAmount.test.ts
  1 file passed, 5 tests passed

pnpm exec eslint apps/xcm-api/src/utils/validateAmount.ts apps/xcm-api/src/utils/validateAmount.test.ts
  passed

pnpm exec prettier --check apps/xcm-api/src/utils/validateAmount.ts apps/xcm-api/src/utils/validateAmount.test.ts
  passed

git diff --check
  passed
```

The full workspace package build is currently blocked on Windows before XCM API compilation by the unchanged `packages/descriptors` PAPI prebuild treating an absolute `C:` path as an unsupported ESM URL. The focused tests and checks above are green; repository CI can exercise the full Linux build.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1gzrNj2jTvQCL8Mo679fdLh9GmFFd379mhkTCQAZzQ5cSrX`

> This is a dedicated self-custody address, not a centralized-exchange address.

---

## 📝 Additional Notes

@michaeldev5
