### PR TITLE
fix(swap): isolate relay ecosystems in routing

### DIFF
--- a/packages/swap/src/assets/filterCompatibleExchanges.ts
+++ b/packages/swap/src/assets/filterCompatibleExchanges.ts
@@ -1,0 +1,35 @@
+import type { TChain, TCustomCtx, TExchangeChain, TRelaychain } from '@paraspell/sdk-core';
+import {
+  getChain,
+  getNativeAssetSymbolImpl,
+  getRelayChainSymbolImpl,
+  isCustomChain,
+  RELAYCHAINS,
+} from '@paraspell/sdk-core';
+
+const getEcosystem = <TCustomChain extends string>(
+  chain: TChain | TCustomChain,
+  ctx?: TCustomCtx,
+): TRelaychain | undefined => {
+  if (!isCustomChain(chain)) {
+    return getChain(chain).ecosystem;
+  }
+
+  const relaySymbol = getRelayChainSymbolImpl(chain, ctx);
+  return RELAYCHAINS.find((relay) => getNativeAssetSymbolImpl(relay) === relaySymbol);
+};
+
+export const filterCompatibleExchanges = <TCustomChain extends string>(
+  exchanges: readonly TExchangeChain[],
+  chain: TChain | TCustomChain | undefined,
+  ctx?: TCustomCtx,
+): TExchangeChain[] => {
+  if (chain === undefined) {
+    return [...exchanges];
+  }
+
+  const ecosystem = getEcosystem(chain, ctx);
+  return ecosystem === undefined
+    ? []
+    : exchanges.filter((exchange) => getChain(exchange).ecosystem === ecosystem);
+};

--- a/packages/swap/src/assets/getSupportedAssetsFrom.test.ts
+++ b/packages/swap/src/assets/getSupportedAssetsFrom.test.ts
@@ -154,4 +154,27 @@ describe('getSupportedAssetsFrom', () => {
     expect(result).toEqual([]);
     expect(getAssetsImpl).not.toHaveBeenCalled();
   });
+
+  it('should not match relative asset locations across relay ecosystems', () => {
+    const dotOnAstar: TAssetInfo = {
+      symbol: 'DOT',
+      decimals: 10,
+      location: { parents: 1, interior: { Here: null } },
+    };
+    const ksmOnAssetHubKusama: TAssetInfo = {
+      symbol: 'KSM',
+      decimals: 12,
+      location: { parents: 1, interior: { Here: null } },
+    };
+
+    vi.mocked(createExchangeInstance).mockReturnValue({
+      chain: 'AssetHubKusama',
+    } as ExchangeChain);
+    vi.mocked(getAssetsImpl).mockReturnValue([dotOnAstar]);
+    vi.mocked(getExchangeAssets).mockReturnValue([ksmOnAssetHubKusama]);
+
+    const result = getSupportedAssetsFrom('Astar', 'AssetHubKusama');
+
+    expect(result).toEqual([]);
+  });
 });

--- a/packages/swap/src/assets/getSupportedAssetsFrom.ts
+++ b/packages/swap/src/assets/getSupportedAssetsFrom.ts
@@ -8,6 +8,7 @@ import {
 } from '@paraspell/sdk-core';
 
 import { createExchangeInstance } from '../exchanges/ExchangeChainFactory';
+import { filterCompatibleExchanges } from './filterCompatibleExchanges';
 import { getExchangeAssets } from './getExchangeConfig';
 
 export const getSupportedAssetsFromImpl = <TCustomChain extends string = never>(
@@ -21,11 +22,19 @@ export const getSupportedAssetsFromImpl = <TCustomChain extends string = never>(
     return getAssetsImpl(from, ctx);
   }
 
-  const exchangeAssets = Array.isArray(exchange)
-    ? exchange.flatMap((exchange) => getExchangeAssets(exchange))
-    : getExchangeAssets(exchange);
+  const exchangeChains = filterCompatibleExchanges(
+    Array.isArray(exchange) ? exchange : [exchange],
+    from,
+    ctx,
+  );
+  const exchangeAssets = exchangeChains.flatMap((exchange) => getExchangeAssets(exchange));
 
-  if (!from || (!Array.isArray(exchange) && from === createExchangeInstance(exchange).chain)) {
+  if (
+    !from ||
+    (exchangeChains.length === 1 &&
+      !Array.isArray(exchange) &&
+      from === createExchangeInstance(exchangeChains[0]).chain)
+  ) {
     return exchangeAssets;
   }
 

--- a/packages/swap/src/assets/getSupportedAssetsTo.test.ts
+++ b/packages/swap/src/assets/getSupportedAssetsTo.test.ts
@@ -168,4 +168,47 @@ describe('getSupportedAssetsTo', () => {
     expect(isSystemAsset).toHaveBeenCalledTimes(assets1.length + assets2.length);
     expect(result).toEqual([abcAsset, defAsset]);
   });
+
+  it('should not match relative asset locations across relay ecosystems', () => {
+    const dotOnAstar: TAssetInfo = {
+      symbol: 'DOT',
+      decimals: 10,
+      location: { parents: 1, interior: { Here: null } },
+    };
+    const ksmOnAssetHubKusama: TAssetInfo = {
+      symbol: 'KSM',
+      decimals: 12,
+      location: { parents: 1, interior: { Here: null } },
+    };
+
+    vi.mocked(getAssetsImpl).mockReturnValue([dotOnAstar]);
+    vi.mocked(getExchangeAssets).mockReturnValue([ksmOnAssetHubKusama]);
+
+    const result = getSupportedAssetsTo('AssetHubKusama', 'Astar');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should restrict auto select to the destination relay ecosystem', () => {
+    const dotOnAstar: TAssetInfo = {
+      symbol: 'DOT',
+      decimals: 10,
+      location: { parents: 1, interior: { Here: null } },
+    };
+    const ksmOnAssetHubKusama: TAssetInfo = {
+      symbol: 'KSM',
+      decimals: 12,
+      location: { parents: 1, interior: { Here: null } },
+    };
+
+    vi.mocked(getAssetsImpl).mockReturnValue([dotOnAstar]);
+    vi.mocked(getExchangeAssets).mockImplementation((exchange) =>
+      exchange === 'AssetHubKusama' ? [ksmOnAssetHubKusama] : [],
+    );
+
+    const result = getSupportedAssetsTo(undefined, 'Astar');
+
+    expect(result).toEqual([]);
+    expect(getExchangeAssets).not.toHaveBeenCalledWith('AssetHubKusama');
+  });
 });

--- a/packages/swap/src/assets/getSupportedAssetsTo.ts
+++ b/packages/swap/src/assets/getSupportedAssetsTo.ts
@@ -9,6 +9,7 @@ import {
   type TChain,
 } from '@paraspell/sdk-core';
 
+import { filterCompatibleExchanges } from './filterCompatibleExchanges';
 import { getExchangeAssets } from './getExchangeConfig';
 
 export const getSupportedAssetsToImpl = <TCustomChain extends string = never>(
@@ -18,9 +19,10 @@ export const getSupportedAssetsToImpl = <TCustomChain extends string = never>(
 ): TAssetInfo[] => {
   const exchange = normalizeExchange(exchangeInput);
   if (exchange === undefined) {
-    const allExchangeAssets = EXCHANGE_CHAINS.map((exchangeChain) =>
+    const compatibleExchanges = filterCompatibleExchanges(EXCHANGE_CHAINS, to, ctx);
+    const allExchangeAssets = compatibleExchanges.flatMap((exchangeChain) =>
       getExchangeAssets(exchangeChain),
-    ).flat();
+    );
     if (to) {
       const toAssets = getAssetsImpl(to, ctx);
 
@@ -35,9 +37,12 @@ export const getSupportedAssetsToImpl = <TCustomChain extends string = never>(
     return allExchangeAssets;
   }
 
-  const exchangeAssets = Array.isArray(exchange)
-    ? exchange.flatMap((exchange) => getExchangeAssets(exchange))
-    : getExchangeAssets(exchange);
+  const compatibleExchanges = filterCompatibleExchanges(
+    Array.isArray(exchange) ? exchange : [exchange],
+    to,
+    ctx,
+  );
+  const exchangeAssets = compatibleExchanges.flatMap((exchange) => getExchangeAssets(exchange));
 
   if (to) {
     const toAssets = getAssetsImpl(to, ctx);

--- a/packages/swap/src/transfer/selectBestExchangeCommon.test.ts
+++ b/packages/swap/src/transfer/selectBestExchangeCommon.test.ts
@@ -1,5 +1,10 @@
 import type { PolkadotApi, TAssetInfo, TExchangeChain, TParachain } from '@paraspell/sdk-core';
-import { applyDecimalAbstraction, findAssetInfo } from '@paraspell/sdk-core';
+import {
+  applyDecimalAbstraction,
+  findAssetInfo,
+  getChain,
+  getRelayChainOf,
+} from '@paraspell/sdk-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getExchangeAsset, getExchangeAssetByOriginAsset } from '../assets';
@@ -14,6 +19,7 @@ const mockApi = { getConfig: () => undefined } as unknown as PolkadotApi<unknown
 vi.mock('@paraspell/sdk-core', async (importActual) => ({
   ...(await importActual()),
   findAssetInfo: vi.fn(),
+  getChain: vi.fn(),
   getRelayChainOf: vi.fn(),
   applyDecimalAbstraction: vi.fn(),
   RoutingResolutionError: class extends Error {},
@@ -61,6 +67,8 @@ describe('selectBestExchangeCommon', () => {
       amount ? (amount as bigint) : 0n,
     );
     vi.clearAllMocks();
+    vi.mocked(getChain).mockReturnValue({ ecosystem: 'Polkadot' } as never);
+    vi.mocked(getRelayChainOf).mockReturnValue('Polkadot');
   });
 
   it('throws error if assetFromOrigin is not found', async () => {
@@ -194,5 +202,32 @@ describe('selectBestExchangeCommon', () => {
 
     expect(bestExchange).toBe(fakeDex);
     expect(getExchangeAsset).toHaveBeenCalledWith('Acala', optionsWithSameChain.currencyFrom);
+  });
+
+  it('skips exchanges outside the destination relay ecosystem', async () => {
+    const options = {
+      ...baseOptions,
+      from: 'Karura',
+      to: 'Astar',
+      exchange: ['AssetHubKusama'],
+    } as TCommonRouterOptions<unknown, unknown, unknown>;
+
+    vi.mocked(findAssetInfo).mockReturnValue(asset1);
+    vi.mocked(getExchangeAssetByOriginAsset).mockReturnValue(asset1);
+    vi.mocked(getExchangeAsset).mockReturnValue(asset2);
+    vi.mocked(getRelayChainOf).mockReturnValue('Kusama');
+    vi.mocked(getChain).mockImplementation(
+      (chain) =>
+        ({
+          ecosystem: chain === 'Astar' ? 'Polkadot' : 'Kusama',
+        }) as never,
+    );
+
+    const fakeDex = { chain: 'AssetHubKusama' } as ExchangeChain;
+    vi.mocked(createExchangeInstance).mockReturnValue(fakeDex);
+    const computeAmountOut = vi.fn().mockResolvedValue(100n);
+
+    await expect(selectBestExchangeCommon(options, undefined, computeAmountOut)).rejects.toThrow();
+    expect(computeAmountOut).not.toHaveBeenCalled();
   });
 });

--- a/packages/swap/src/transfer/selectBestExchangeCommon.ts
+++ b/packages/swap/src/transfer/selectBestExchangeCommon.ts
@@ -3,6 +3,7 @@ import {
   applyDecimalAbstraction,
   EXCHANGE_CHAINS,
   findAssetInfo,
+  getChain,
   getRelayChainOf,
   isConfig,
   RoutingResolutionError,
@@ -65,6 +66,14 @@ export const selectBestExchangeCommon = async <
   let triedAnyExchange = false;
   for (const exchangeChain of filteredExchangeChains) {
     const dex = createExchangeInstance(exchangeChain);
+    const exchangeEcosystem = getRelayChainOf(dex.chain);
+
+    if (
+      (from && getRelayChainOf(from) !== exchangeEcosystem) ||
+      (to && getChain(to).ecosystem !== exchangeEcosystem)
+    ) {
+      continue;
+    }
 
     const originSpecified = from && from !== dex.chain;
     const destinationSpecified = to && to !== dex.chain;
@@ -85,10 +94,6 @@ export const selectBestExchangeCommon = async <
     }
 
     if (destinationSpecified && !findAssetInfo(to, { location: assetTo.location })) {
-      continue;
-    }
-
-    if (from && getRelayChainOf(from) !== getRelayChainOf(dex.chain)) {
       continue;
     }
 


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2002

---

## 🛠️ Description of the Fix

- Bug description: SWAP compared chain-relative XCM locations across relay ecosystems. Identical relative locations can represent different assets on Polkadot, Kusama, Paseo, and Westend, producing false discovery results and allowing destination-incompatible exchanges into auto-selection.
- Fix summary: Filter candidate exchanges by the reference chain's relay ecosystem before asset matching, resolve built-in/external/custom-chain ecosystems, and reject exchanges that are incompatible with the destination during automatic routing.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1C716S3HZYa9U58xTWw5LfPvFyb7qRL9BdBTYKx3tRxdDdJ`

---

## 🧩 Additional Notes

Validation completed:

- `pnpm --dir packages/swap compile`
- `pnpm --dir packages/swap lint:check`
- `vitest run` — 59 files, 353 tests passed
- `pnpm --dir packages/swap build`

Regression coverage includes Astar versus AssetHubKusama discovery collisions and destination-ecosystem filtering in `selectBestExchangeCommon`.


---

## Review request

@michaeldev5, please review this bug bounty fix when available.