### PR TITLE
fix(swap): preserve fee asset exchange provenance

### DIFF
--- a/packages/swap/src/assets/getSupportedFeeAssets.test.ts
+++ b/packages/swap/src/assets/getSupportedFeeAssets.test.ts
@@ -1,5 +1,5 @@
 import type { TAssetInfo, TExchangeChain, TSubstrateChain } from '@paraspell/sdk-core';
-import { getAssetsImpl, isAssetEqual } from '@paraspell/sdk-core';
+import { EXCHANGE_CHAINS, getAssetsImpl, isAssetEqual } from '@paraspell/sdk-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createExchangeInstance } from '../exchanges/ExchangeChainFactory';
@@ -99,7 +99,10 @@ describe('getSupportedFeeAssets', () => {
     const result = getSupportedFeeAssets(undefined, undefined);
 
     expect(result).toEqual([feeAsset]);
-    expect(getSupportedAssetsFromImpl).toHaveBeenCalledWith(undefined, undefined, undefined);
+    expect(getSupportedAssetsFromImpl).toHaveBeenCalledTimes(EXCHANGE_CHAINS.length);
+    EXCHANGE_CHAINS.forEach((exchange) => {
+      expect(getSupportedAssetsFromImpl).toHaveBeenCalledWith(undefined, exchange, undefined);
+    });
   });
 
   it('should gather assets from multiple exchanges when exchange is array and from undefined', () => {
@@ -139,6 +142,44 @@ describe('getSupportedFeeAssets', () => {
     vi.mocked(getAssetsImpl).mockReturnValue([nonFeeAsset]);
 
     const result = getSupportedFeeAssets(from, undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should not borrow fee eligibility across selected exchanges', () => {
+    const hydrationAsset: TAssetInfo = {
+      symbol: 'HDX-ASSET',
+      decimals: 12,
+      location: { parents: 1, interior: { X1: [{ Parachain: 2034 }] } },
+    };
+    const acalaAsset: TAssetInfo = {
+      symbol: 'ACA-ASSET',
+      decimals: 12,
+      location: { parents: 1, interior: { X1: [{ Parachain: 2000 }] } },
+    };
+    const hydrationFeeAsset: TAssetInfo = {
+      ...acalaAsset,
+      symbol: 'HYDRATION-FEE',
+      isFeeAsset: true,
+    };
+    const acalaFeeAsset: TAssetInfo = {
+      ...hydrationAsset,
+      symbol: 'ACALA-FEE',
+      isFeeAsset: true,
+    };
+
+    vi.mocked(createExchangeInstance).mockImplementation(
+      (exchange) => ({ chain: exchange }) as never,
+    );
+    vi.mocked(getSupportedAssetsFromImpl).mockImplementation((_from, exchange) => {
+      if (Array.isArray(exchange)) return [hydrationAsset, acalaAsset];
+      return exchange === 'Hydration' ? [hydrationAsset] : [acalaAsset];
+    });
+    vi.mocked(getAssetsImpl).mockImplementation((chain) =>
+      chain === 'Hydration' ? [hydrationAsset, hydrationFeeAsset] : [acalaAsset, acalaFeeAsset],
+    );
+
+    const result = getSupportedFeeAssets(undefined, ['Hydration', 'Acala']);
 
     expect(result).toEqual([]);
   });

--- a/packages/swap/src/assets/getSupportedFeeAssets.ts
+++ b/packages/swap/src/assets/getSupportedFeeAssets.ts
@@ -12,24 +12,45 @@ import {
 import { createExchangeInstance } from '../exchanges/ExchangeChainFactory';
 import { getSupportedAssetsFromImpl } from './getSupportedAssetsFrom';
 
+const filterFeeAssets = <TCustomChain extends string>(
+  supportedAssets: TAssetInfo[],
+  chain: TChain | TCustomChain,
+  ctx?: TCustomCtx,
+): TAssetInfo[] => {
+  const chainAssets = getAssetsImpl(chain, ctx);
+  return supportedAssets.filter((asset) =>
+    chainAssets.some((chainAsset) => chainAsset.isFeeAsset && isAssetEqual(asset, chainAsset)),
+  );
+};
+
+const deduplicateAssets = (assets: TAssetInfo[]): TAssetInfo[] =>
+  assets.filter(
+    (asset, index) =>
+      assets.findIndex(
+        (candidate) => candidate.symbol === asset.symbol && isAssetEqual(candidate, asset),
+      ) === index,
+  );
+
 export const getSupportedFeeAssetsImpl = <TCustomChain extends string = never>(
   from: TChain | TCustomChain | undefined,
   exchangeInput: TExchangeInput,
   ctx?: TCustomCtx,
 ): TAssetInfo[] => {
   const exchange = normalizeExchange(exchangeInput);
-  const supportedAssets = getSupportedAssetsFromImpl(from, exchange, ctx);
 
-  const chains = from
-    ? [from]
-    : (exchange === undefined ? EXCHANGE_CHAINS : Array.isArray(exchange) ? exchange : [exchange])
-        .map((ex) => createExchangeInstance(ex).chain)
-        .filter((chain, i, arr) => arr.indexOf(chain) === i);
+  if (from !== undefined) {
+    return filterFeeAssets(getSupportedAssetsFromImpl(from, exchange, ctx), from, ctx);
+  }
 
-  const chainAssets = chains.flatMap((chain) => getAssetsImpl(chain, ctx));
+  const exchanges =
+    exchange === undefined ? EXCHANGE_CHAINS : Array.isArray(exchange) ? exchange : [exchange];
 
-  return supportedAssets.filter((asset) =>
-    chainAssets.some((chainAsset) => chainAsset.isFeeAsset && isAssetEqual(asset, chainAsset)),
+  return deduplicateAssets(
+    exchanges.flatMap((currentExchange) => {
+      const chain = createExchangeInstance(currentExchange).chain;
+      const supportedAssets = getSupportedAssetsFromImpl(undefined, currentExchange, ctx);
+      return filterFeeAssets(supportedAssets, chain, ctx);
+    }),
   );
 };
 


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2004

---

## 🛠️ Description of the Fix

- Bug description: `getSupportedFeeAssets` flattened assets from multiple exchanges before applying fee markers. This let an asset from one exchange borrow fee eligibility from a matching relative location on another chain.
- Fix summary: Evaluate each exchange against its own underlying chain assets, preserve exchange provenance during fee filtering, and deduplicate only after collecting the independently valid results.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1C716S3HZYa9U58xTWw5LfPvFyb7qRL9BdBTYKx3tRxdDdJ`

---

## 🧩 Additional Notes

Validation completed:

- TypeScript compile passed
- ESLint passed
- Prettier passed for both changed files
- Rollup build passed
- Vitest — 59 files, 350 tests passed
- Post-build invariant check — all 36 exchange pairs checked, 0 anomalous pairs

The regression deliberately crosses fee markers between Hydration and Acala assets, demonstrating the false-positive behavior before this change.


---

## Review request

@michaeldev5, please review this bug bounty fix when available.