### PR TITLE
fix(swap): reject unresolved fee assets

### DIFF
--- a/packages/swap/src/transfer/utils/resolveAssets.test.ts
+++ b/packages/swap/src/transfer/utils/resolveAssets.test.ts
@@ -238,4 +238,58 @@ describe('resolveAssets', () => {
 
     expect(() => resolveAssets(dex, options)).toThrow('is not a valid fee asset');
   });
+
+  it('throws error when feeAsset is not found on the exchange chain', () => {
+    const options = {
+      currencyFrom: { symbol: 'BTC' },
+      currencyTo: { symbol: 'ETH' },
+      feeAsset: { symbol: 'UNKNOWN' },
+    } as TTransferBaseOptions<unknown, unknown, unknown>;
+
+    vi.mocked(getExchangeAsset).mockImplementation((_exchangeChain, currency) => {
+      if ('symbol' in currency && currency.symbol === 'BTC') return mockAssetFromExchange;
+      if ('symbol' in currency && currency.symbol === 'ETH') return mockAssetTo;
+      return null;
+    });
+
+    expect(() => resolveAssets(dex, options)).toThrow(
+      'Fee asset {"symbol":"UNKNOWN"} not found in CHAIN_A.',
+    );
+    expect(findAssetInfoOrThrow).not.toHaveBeenCalled();
+  });
+
+  it('keeps an origin fee asset even when it is unavailable on the exchange chain', () => {
+    const feeAssetFromOrigin: TAssetInfo = {
+      symbol: 'USDT_ORIGIN',
+      decimals: 6,
+      location: { parents: 1, interior: { X1: { PalletInstance: 50 } } },
+      isFeeAsset: true,
+    };
+    const options = {
+      from: 'Astar',
+      currencyFrom: { symbol: 'BTC' },
+      currencyTo: { symbol: 'ETH' },
+      feeAsset: { symbol: 'USDT' },
+    } as TTransferBaseOptions<unknown, unknown, unknown>;
+
+    vi.mocked(findAssetInfo)
+      .mockReturnValueOnce({ symbol: 'BTC_ORIGIN', decimals: 8 } as TAssetInfo)
+      .mockReturnValueOnce(feeAssetFromOrigin);
+    vi.mocked(getExchangeAssetByOriginAsset)
+      .mockReturnValueOnce(mockAssetFromExchange)
+      .mockReturnValueOnce(undefined);
+    vi.mocked(getExchangeAsset).mockImplementation((_exchangeChain, currency) => {
+      if ('symbol' in currency && currency.symbol === 'ETH') return mockAssetTo;
+      return null;
+    });
+    vi.mocked(findAssetInfoOrThrow).mockReturnValue(feeAssetFromOrigin);
+
+    expect(resolveAssets(dex, options)).toEqual({
+      assetFromOrigin: { symbol: 'BTC_ORIGIN', decimals: 8 },
+      assetFromExchange: mockAssetFromExchange,
+      assetTo: mockAssetTo,
+      feeAssetFromOrigin,
+      feeAssetFromExchange: undefined,
+    });
+  });
 });

--- a/packages/swap/src/transfer/utils/resolveAssets.ts
+++ b/packages/swap/src/transfer/utils/resolveAssets.ts
@@ -75,6 +75,12 @@ export const resolveAssets = <TApi, TRes, TSigner>(
       : (getExchangeAsset(dex.chain, feeAsset) ?? undefined)
     : undefined;
 
+  if (feeAsset && !feeAssetFromOrigin && !feeAssetFromExchange) {
+    throw new RoutingResolutionError(
+      `Fee asset ${JSON.stringify(feeAsset)} not found in ${from ?? dex.chain}.`,
+    );
+  }
+
   const resolvedFeeAssetLocation = feeAssetFromOrigin?.location ?? feeAssetFromExchange?.location;
 
   if (feeAsset && resolvedFeeAssetLocation) {


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2006

---

## 🛠️ Description of the Fix

- **Bug description:** An explicitly supplied `feeAsset` could resolve to neither the origin asset nor the exchange asset without triggering an error. The undefined value then propagated to execute-transfer construction, which silently switched to the main-asset/default fee path.
- **Root cause:** `resolveAssets` validated a resolved fee asset's eligibility, but had no guard for the case where resolution returned nothing at all.
- **Fix summary:** Reject the route with `RoutingResolutionError` when an explicit fee asset is unresolved on both relevant chains.
- **Compatibility:** Keep origin-only fee assets valid. They are still accepted even when they have no exchange representation, because the origin asset pays the first XCM leg.

The change is deliberately limited to one guard in `resolveAssets` and two regression tests.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation changes are not required; this restores deterministic validation of the existing API contract.
- [x] I have verified the fix does not introduce new issues.

Validation completed:

- 59 test files / 351 tests passed
- TypeScript compilation passed
- ESLint passed
- Prettier passed on both changed files
- Rollup package build passed

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1C716S3HZYa9U58xTWw5LfPvFyb7qRL9BdBTYKx3tRxdDdJ`

> ⚠️ This is a self-custody Polkadot Asset Hub address, not a centralized exchange address.

---

## 🧩 Additional Notes

The regression coverage checks both sides of the boundary:

1. An unresolvable exchange-origin fee asset now fails early with the requested asset and chain in the error.
2. A separately specified origin fee asset remains valid even if no equivalent exchange asset exists.


---

## Review request

@michaeldev5, please review this bug bounty fix when available.