### PR TITLE
fix(sdk): wait for PAPI transaction finalization

### DIFF
--- a/packages/sdk/src/PapiApi.test.ts
+++ b/packages/sdk/src/PapiApi.test.ts
@@ -2943,12 +2943,14 @@ describe('PapiApi', () => {
       expect(result).toBe(mockTxHash)
     })
 
-    it('should resolve on txBestBlocksState with found', async () => {
-      const mockTxHash = '0xbestblock'
+    it('should wait for finalization after a transaction appears in a best block', async () => {
+      const bestBlockTxHash = '0xbestblock'
+      const finalizedTxHash = '0xfinalized'
       const mockSubscribe = vi
         .fn()
         .mockImplementation(({ next }: { next: (event: unknown) => void }) => {
-          next({ type: 'txBestBlocksState', found: true, ok: true, txHash: mockTxHash })
+          next({ type: 'txBestBlocksState', found: true, ok: true, txHash: bestBlockTxHash })
+          next({ type: 'finalized', ok: true, txHash: finalizedTxHash })
         })
       const mockTx = {
         signSubmitAndWatch: vi.fn().mockReturnValue({ subscribe: mockSubscribe })
@@ -2956,7 +2958,7 @@ describe('PapiApi', () => {
 
       const result = await papiApi.signAndSubmitFinalized(mockTx, '//Alice')
 
-      expect(result).toBe(mockTxHash)
+      expect(result).toBe(finalizedTxHash)
     })
 
     it('should reject with SubmitTransactionError on dispatch error', async () => {

--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -943,7 +943,7 @@ class PapiApi<TCustomChain extends string = never> extends PolkadotApi<
     return new Promise((resolve, reject) => {
       tx.signSubmitAndWatch(signer).subscribe({
         next: event => {
-          if (event.type === 'finalized' || (event.type === 'txBestBlocksState' && event.found)) {
+          if (event.type === 'finalized') {
             if (!event.ok) {
               reject(new SubmitTransactionError(JSON.stringify(event.dispatchError.value)))
             } else {


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2009

---

## 🛠️ Description of the Fix

- **Bug description:** The PAPI implementation of `signAndSubmitFinalized` resolved on provisional `txBestBlocksState { found: true }` inclusion instead of waiting for the transaction's `finalized` event.
- **Impact:** Callers could receive success for a transaction still subject to best-chain pruning. The SWAP router awaits this method between dependent plan steps, so the PAPI backend could submit the next step and report completion before the first transaction was final.
- **Backend inconsistency:** Polkadot.js already waits for `status.isFinalized`; Dedot already uses `untilFinalized()`.
- **Fix summary:** Ignore best-block inclusion events and preserve the existing success/error handling exclusively for `type: 'finalized'`.

The regression test emits distinct best-block and finalized hashes and asserts that the method returns the finalized hash. This test fails on current main because the promise settles on the first provisional event.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation changes are not required; the change restores the existing method contract.
- [x] I have verified the fix does not introduce new issues.

Validation completed:

- 14 test files / 236 tests passed
- TypeScript compilation passed
- ESLint passed
- Prettier passed on both changed files
- Rollup SDK build passed

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1C716S3HZYa9U58xTWw5LfPvFyb7qRL9BdBTYKx3tRxdDdJ`

> ⚠️ This is a self-custody Polkadot Asset Hub address, not a centralized exchange address.

---

## 🧩 Additional Notes

PAPI documents that `txBestBlocksState` can be emitted repeatedly as a transaction appears in and disappears from the current best-chain branch. Only the later `finalized` event satisfies this method's guarantee:

https://papi.how/typed/tx/


---

## Review request

@michaeldev5, please review this bug bounty fix when available.