### PR TITLE
fix(sdk-dedot): reject finalized dispatch errors

### DIFF
--- a/packages/sdk-dedot/src/DedotApi.test.ts
+++ b/packages/sdk-dedot/src/DedotApi.test.ts
@@ -13,6 +13,7 @@ import {
   isSenderSigner,
   localizeLocation,
   RuntimeApiUnavailableError,
+  SubmitTransactionError,
   type TLocation,
   type TSubstrateChain,
   Version,
@@ -1863,6 +1864,24 @@ describe("DedotApi", () => {
 
       expect(signAndSendSpy).toHaveBeenCalled();
       expect(result).toBe(mockTxHash);
+    });
+
+    it("should reject with SubmitTransactionError on dispatch error", async () => {
+      const mockTx = {
+        signAndSend: vi.fn().mockReturnValue({
+          untilFinalized: vi.fn().mockResolvedValue({
+            txHash: "0xfailed",
+            dispatchError: {
+              type: "Module",
+              value: { index: 5, error: 2 },
+            },
+          }),
+        }),
+      } as unknown as TDedotExtrinsic;
+
+      await expect(
+        dedotApi.signAndSubmitFinalized(mockTx, "//Alice"),
+      ).rejects.toThrow(SubmitTransactionError);
     });
 
     it("should propagate errors from untilFinalized", async () => {

--- a/packages/sdk-dedot/src/DedotApi.ts
+++ b/packages/sdk-dedot/src/DedotApi.ts
@@ -46,6 +46,7 @@ import {
   RELAY_LOCATION,
   replaceBigInt,
   RuntimeApiUnavailableError,
+  SubmitTransactionError,
   UnsupportedOperationError,
   wrapTxBypass,
 } from "@paraspell/sdk-core";
@@ -942,6 +943,13 @@ class DedotApi<TCustomChain extends string = never> extends PolkadotApi<
   ): Promise<string> {
     const account = isSenderSigner(sender) ? sender : createKeyringPair(sender);
     const result = await tx.signAndSend(account).untilFinalized();
+
+    if (result.dispatchError) {
+      throw new SubmitTransactionError(
+        JSON.stringify(result.dispatchError, replaceBigInt),
+      );
+    }
+
     return result.txHash;
   }
 }


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2011

---

## 🛠️ Description of the Fix

- Bug description: Dedot's `signAndSubmitFinalized` returned `txHash` after finalization even when the finalized result contained a `dispatchError`, so a failed extrinsic was reported as successful.
- Fix summary: Reject finalized dispatch errors with `SubmitTransactionError` before returning the hash, matching the PAPI and Polkadot.js backend behavior.
- Regression coverage: Added a test with a finalized module dispatch error and verified the promise rejects.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] Documentation changes are not required for this internal consistency fix.
- [x] I have verified the fix does not introduce new issues.

Validation performed:
- `@paraspell/sdk-dedot` tests: 7 files / 170 tests passed
- TypeScript compile passed
- ESLint passed
- Package build passed

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `1C716S3HZYa9U58xTWw5LfPvFyb7qRL9BdBTYKx3tRxdDdJ`

> This is a self-custody Polkadot Asset Hub address, not a centralized exchange address.

---

## 🧩 Additional Notes

Dedot documents that `untilFinalized()` resolves a finalized `SubmittableResult`, while runtime failure information is exposed through `dispatchError`. The guard prevents higher-level route execution from continuing after a failed extrinsic.