### PR TITLE
fix: HTML-escape user inputs in email templates (#2008)

### DIFF
--- a/apps/xcm-api/src/auth/utils/escapeHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/escapeHtml.test.ts
@@ -1,0 +1,29 @@
+import { escapeHtml } from './escapeHtml.js';
+
+describe('escapeHtml', () => {
+  it('should escape HTML special characters', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
+    );
+  });
+
+  it('should escape ampersands', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  it('should escape quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+    expect(escapeHtml("it's")).toBe('it&#039;s');
+  });
+
+  it('should escape link injection attempts', () => {
+    const injected = '</span><a href="https://attacker.example">Review request</a><span>';
+    const escaped = escapeHtml(injected);
+    expect(escaped).not.toContain('<a href=');
+    expect(escaped).toContain('&lt;a href=');
+  });
+
+  it('should leave safe text unchanged', () => {
+    expect(escapeHtml('Increase API usage')).toBe('Increase API usage');
+  });
+});

--- a/apps/xcm-api/src/auth/utils/escapeHtml.ts
+++ b/apps/xcm-api/src/auth/utils/escapeHtml.ts
@@ -1,0 +1,13 @@
+/**
+ * Escapes HTML special characters to prevent injection in HTML email templates.
+ * @param unsafe - The untrusted string to escape
+ * @returns The escaped string safe for interpolation into HTML
+ */
+export const escapeHtml = (unsafe: string): string => {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};

--- a/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './escapeHtml.js';
+
 export const generateConfirmationEmailHtml = (
   title: string,
   reason: string,
@@ -182,8 +184,8 @@ export const generateConfirmationEmailHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${escapeHtml(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${escapeHtml(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->

--- a/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './escapeHtml.js';
+
 export const generateNewHigherLimitRequestHtml = (
   userEmail: string,
   userId: string,
@@ -183,10 +185,10 @@ export const generateNewHigherLimitRequestHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${userEmail}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${userId}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${escapeHtml(userEmail)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${escapeHtml(userId)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${escapeHtml(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${escapeHtml(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue
Closes #2008

## 🛠️ Description of the Fix
- Bug description: `generateNewHigherLimitRequestHtml` and `generateConfirmationEmailHtml` interpolate requester-controlled values (`email`, `reason`, `requestedLimit`) directly into HTML without encoding, enabling HTML/link injection in trusted ParaSpell emails.
- Fix summary: Added `escapeHtml` utility that escapes `&`, `<`, `>`, `"`, `'` and applied it to all user-controlled interpolations in both email templates.

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective (5 tests for escapeHtml covering injection vectors).
- [x] I have verified the fix does not introduce new issues.

## 💸 Polkadot Asset Hub Address (for Reward)
`1UVS7pBoNzR3hL5xFgJawxw1pXcmoN1rXcrXcN2qDwQEj5U`
