### PR TITLE
fix: check dispatchError in signAndSubmitFinalized (#2011)

### DIFF
--- a/packages/sdk-dedot/src/DedotApi.ts
+++ b/packages/sdk-dedot/src/DedotApi.ts
@@ -942,6 +942,9 @@ class DedotApi<TCustomChain extends string = never> extends PolkadotApi<
   ): Promise<string> {
     const account = isSenderSigner(sender) ? sender : createKeyringPair(sender);
     const result = await tx.signAndSend(account).untilFinalized();
+    if (result.dispatchError) {
+      throw new SubmitTransactionError(result.dispatchError, result.txHash);
+    }
     return result.txHash;
   }
 }


### PR DESCRIPTION
## Fix for #2011

### Problem
`signAndSubmitFinalized` in `DedotApi.ts` returns `result.txHash` without checking `result.dispatchError`. A finalized extrinsic that failed at runtime is reported as successful.

### Fix
Added `dispatchError` check after `untilFinalized()` resolves. If `dispatchError` is present, throw `SubmitTransactionError` — consistent with the PAPI and Polkadot.js backends.

### Changes
- `packages/sdk-dedot/src/DedotApi.ts`: Added dispatchError check before returning txHash

### Validation
- TypeScript compiles cleanly
- Existing test suite passes
