### PR TITLE
fix: guard forwardedXcm[1] access in getDeliveryFee (#2015)

### DIFF
--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -581,7 +581,7 @@ class PapiApi<TCustomChain extends string = never> extends PolkadotApi<
     let usedThirdParam = false
     let deliveryFeeRes: any
 
-    if (forwardedXcm.length > 0) {
+    if (forwardedXcm.length > 1) {
       const baseArgs = [forwardedXcm[0], forwardedXcm[1][0]] as const
 
       try {


### PR DESCRIPTION
## Fix for #2015

### Problem
`getDeliveryFee` accesses `forwardedXcm[1][0]` after only checking `forwardedXcm.length > 0`. When the array has exactly 1 element, `forwardedXcm[1]` is `undefined`, causing a crash.

### Fix
Changed the guard from `forwardedXcm.length > 0` to `forwardedXcm.length > 1` so the code only accesses index 1 when it exists.

### Testing
The existing test suite covers the multi-element case. Single-element arrays will now gracefully skip the second-element access path.

Fixes #2015