### PR TITLE
fix: guard single forwarded XCM delivery fee

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -777,6 +777,21 @@ describe('PolkadotJsApi', () => {
       expect(fee).toBe(304850000n)
     })
 
+    it('returns zero delivery fee for a single forwarded XCM without crashing', async () => {
+      const forwardedXcm: unknown[] = [{ some: 'xcm0' }]
+
+      const fee = await polkadotApi.getDeliveryFee(
+        'AssetHubPolkadot',
+        forwardedXcm,
+        dotAsset,
+        dotAsset.location,
+        Version.V5
+      )
+
+      expect(mockApiPromise.call.xcmPaymentApi.queryDeliveryFees).not.toHaveBeenCalled()
+      expect(fee).toBe(0n)
+    })
+
     it('rethrows errors from queryDeliveryFees when not an arity mismatch', async () => {
       const forwardedXcm0 = { some: 'xcm0' }
       const forwardedXcm1 = { some: 'xcm1' }

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -545,7 +545,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     let usedThirdParam = false
     let deliveryFeeRes: any
 
-    if (forwardedXcm.length > 0) {
+    if (forwardedXcm.length > 1 && Array.isArray(forwardedXcm[1]) && forwardedXcm[1].length > 0) {
       const baseArgs = [forwardedXcm[0], forwardedXcm[1][0]] as const
 
       try {


### PR DESCRIPTION
## Summary\n- guard queryDeliveryFees so single-element forwardedXcm arrays do not access forwardedXcm[1][0]\n- return zero delivery fee when there is no second forwarded XCM fee payload\n- add regression coverage for single forwarded XCM arrays\n\nFixes #2015\n\n## Tests\n- pnpm --filter @paraspell/sdk-pjs compile\n- pnpm --filter @paraspell/sdk-pjs exec vitest run src/PolkadotJsApi.test.ts\n\nNote: this environment runs Node v22.22.0 while the repo requests Node >=24, so pnpm emitted an engine warning.