### PR TITLE
fix(visualizer): scope channel message counts to ecosystem

### DIFF
--- a/apps/visualizer-be/src/channels/channels.service.test.ts
+++ b/apps/visualizer-be/src/channels/channels.service.test.ts
@@ -201,6 +201,13 @@ describe('ChannelService', () => {
         active_at: 123456,
         status: 'accepted',
       });
+
+      expect(prisma.$queryRawUnsafe).toHaveBeenCalledWith(
+        expect.stringContaining('msg.ecosystem = ch.ecosystem'),
+        ecosystem,
+        sender,
+        recipient,
+      );
     });
 
     it('should throw when no channel is found', async () => {

--- a/apps/visualizer-be/src/channels/channels.service.ts
+++ b/apps/visualizer-be/src/channels/channels.service.ts
@@ -118,7 +118,8 @@ export class ChannelService {
         channels ch
       LEFT JOIN
         messages msg
-          ON msg.origin_para_id = ch.sender
+          ON msg.ecosystem = ch.ecosystem
+         AND msg.origin_para_id = ch.sender
          AND msg.dest_para_id = ch.recipient
       WHERE
         ch.ecosystem = $1


### PR DESCRIPTION
Closes #2028

Summary:
- Restricts the channel detail join to the requested relay ecosystem.
- Adds a regression assertion for the ecosystem predicate.

Validation:
- Channel service suite: 10 tests passed.
- TypeScript compilation, ESLint, and Prettier checks passed.

@michaeldev5, please review this bug bounty fix when available.