### PR TITLE
[Bug bounty] Fix: accountCounts crashes when nullable paraIds is omitted or null (#2034)

### DIFF
--- a/apps/visualizer-be/src/messages/messages.resolver.test.ts
+++ b/apps/visualizer-be/src/messages/messages.resolver.test.ts
@@ -173,6 +173,52 @@ describe('MessageResolver', () => {
         endTime.getTime(),
       );
     });
+
+    it('should default paraIds to empty array when null (bug bounty #2034)', async () => {
+      const expected = [{ account: '0x456', count: 3 }];
+      const threshold = 5;
+      service.getAccountXcmCounts.mockResolvedValue(expected);
+
+      const result = await resolver.accountCounts(
+        ecosystem,
+        threshold,
+        null,
+        startTime,
+        endTime,
+      );
+
+      expect(result).toEqual(expected);
+      expect(service.getAccountXcmCounts).toHaveBeenCalledWith(
+        ecosystem,
+        [],
+        threshold,
+        startTime.getTime(),
+        endTime.getTime(),
+      );
+    });
+
+    it('should default paraIds to empty array when undefined (bug bounty #2034)', async () => {
+      const expected = [{ account: '0x789', count: 1 }];
+      const threshold = 5;
+      service.getAccountXcmCounts.mockResolvedValue(expected);
+
+      const result = await resolver.accountCounts(
+        ecosystem,
+        threshold,
+        undefined,
+        startTime,
+        endTime,
+      );
+
+      expect(result).toEqual(expected);
+      expect(service.getAccountXcmCounts).toHaveBeenCalledWith(
+        ecosystem,
+        [],
+        threshold,
+        startTime.getTime(),
+        endTime.getTime(),
+      );
+    });
   });
 
   describe('totalMessageCounts', () => {

--- a/apps/visualizer-be/src/messages/messages.resolver.ts
+++ b/apps/visualizer-be/src/messages/messages.resolver.ts
@@ -77,13 +77,14 @@ export class MessageResolver {
   async accountCounts(
     @Args('ecosystem', { type: () => String }) ecosystem: string,
     @Args('threshold', { type: () => Int }) threshold: number,
-    @Args('paraIds', { type: () => [Int], nullable: true }) paraIds: number[],
+    @Args('paraIds', { type: () => [Int], nullable: true })
+    paraIds: number[],
     @Args('startTime', { type: () => Date }) startTime: Date,
     @Args('endTime', { type: () => Date }) endTime: Date,
   ) {
     return this.messageService.getAccountXcmCounts(
       ecosystem,
-      paraIds,
+      paraIds ?? [],
       threshold,
       startTime.getTime(),
       endTime.getTime(),

--- a/apps/visualizer-be/src/messages/messages.service.ts
+++ b/apps/visualizer-be/src/messages/messages.service.ts
@@ -372,7 +372,7 @@ export class MessageService {
 
   async getAccountXcmCounts(
     ecosystem: string,
-    paraIds: number[],
+    paraIds: number[] | null | undefined,
     threshold: number,
     startTime: number,
     endTime: number,
@@ -385,12 +385,13 @@ export class MessageService {
 
     const parameters: (string | number)[] = [ecosystem, startTime, endTime];
 
-    if (paraIds.length > 0) {
-      const inClause = paraIds
+    const paraIdList = paraIds ?? [];
+    if (paraIdList.length > 0) {
+      const inClause = paraIdList
         .map((_, idx) => `$${idx + 4}`) // $4, $5, ...
         .join(', ');
       whereConditions.push(`origin_para_id IN (${inClause})`);
-      parameters.push(...paraIds);
+      parameters.push(...paraIdList);
     }
     parameters.push(threshold);
 


### PR DESCRIPTION
## Bug

Fixes #2034

The XCM Visualizer BE GraphQL query `accountCounts` declares `paraIds` as nullable:

```ts
@Args('paraIds', { type: () => [Int], nullable: true }) paraIds: number[]
```

However, when the argument is omitted or explicitly set to `null`, the resolver forwarded `null`/`undefined` to `MessageService.getAccountXcmCounts`, which reads `paraIds.length` unconditionally — causing a runtime `TypeError`.

## Root Cause

1. **Resolver** (`messages.resolver.ts`): passed `paraIds` directly to the service without defaulting, so `null`/`undefined` propagated through.
2. **Service** (`messages.service.ts`): `if (paraIds.length > 0)` throws `TypeError: Cannot read properties of null/undefined (reading 'length')`.

## Fix

1. **Resolver**: `paraIds ?? []` — coalesce null/undefined to an empty array before calling the service.
2. **Service**: accept `paraIds: number[] | null | undefined` and internally coalesce with `const paraIdList = paraIds ?? []`, so the no-parachain-filter behavior works correctly when no paraIds are provided.

## Tests

Added two new test cases in `messages.resolver.test.ts`:
- `should default paraIds to empty array when null` — verifies the resolver passes `[] ` to the service when `paraIds` is `null`.
- `should default paraIds to empty array when undefined` — same for `undefined`.

Both verify the service is called with `[]` rather than `null`/`undefined`, preventing the crash.

## Verification

```
pnpm test messages.resolver
```

The existing test `should call getAccountXcmCounts with correct args` (valid paraIds) continues to pass unchanged.