### PR TITLE
[Bug bounty] Fix: PapiApi.getDeliveryFee crashes on single-element forwardedXcm array (#2015)

### DIFF
--- a/packages/sdk/src/PapiApi.test.ts
+++ b/packages/sdk/src/PapiApi.test.ts
@@ -659,6 +659,22 @@ describe('PapiApi', () => {
       expect(res).toBe(0n)
     })
 
+    it('returns 0n when forwardedXcm has a single element (bug bounty #2015)', async () => {
+      const unsafeApi = papiApi.api.getUnsafeApi()
+      const forwardedXcm = [{ /* msg */ }] // only one element, length = 1
+
+      const res = await papiApi.getDeliveryFee(
+        chain,
+        forwardedXcm,
+        baseAsset,
+        baseAsset.location,
+        Version.V5
+      )
+
+      expect(unsafeApi.apis.XcmPaymentApi.query_delivery_fees).not.toHaveBeenCalled()
+      expect(res).toBe(0n)
+    })
+
     it('returns 0n when delivery fee response type is Unimplemented', async () => {
       const unsafeApi = papiApi.api.getUnsafeApi()
       const forwardedXcm = [{}, [{}]]

--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -581,7 +581,7 @@ class PapiApi<TCustomChain extends string = never> extends PolkadotApi<
     let usedThirdParam = false
     let deliveryFeeRes: any
 
-    if (forwardedXcm.length > 0) {
+    if (forwardedXcm.length > 1) {
       const baseArgs = [forwardedXcm[0], forwardedXcm[1][0]] as const
 
       try {


### PR DESCRIPTION
## Bug

Fixes #2015

`PapiApi.ts` line 584 guarded with `forwardedXcm.length > 0` but line 585 accessed `forwardedXcm[1][0]`, which requires the array to have at least 2 elements. A single-element array passed the guard, then `forwardedXcm[1]` was `undefined`, causing:

```
TypeError: Cannot read properties of undefined (reading '0')
```

## Root Cause

```ts
// BUG: guard checks > 0, but body accesses [1][0] — needs > 1
if (forwardedXcm.length > 0) {
  const baseArgs = [forwardedXcm[0], forwardedXcm[1][0]] as const
  ...
}
```

The surrounding try/catch only handles `Incompatible runtime entry` errors; a `TypeError` does not match and is re-thrown, crashing fee calculation.

## Fix

Change the guard from `length > 0` to `length > 1`:

```ts
if (forwardedXcm.length > 1) {
  const baseArgs = [forwardedXcm[0], forwardedXcm[1][0]] as const
  ...
}
```

A single-element array now correctly skips the delivery fee query block (same as an empty array), and `deliveryFeeRes` remains `undefined`, resulting in `deliveryFeeResolved = 0n`.

## Tests

Added test: `returns 0n when forwardedXcm has a single element` — verifies that with `forwardedXcm = [{ /* msg */ }]` (length 1), `query_delivery_fees` is never called and the result is `0n`.