### PR TITLE
[Bug bounty] Fix: HTML injection in higher-limit request and confirmation email templates (#2008)

### DIFF
--- a/apps/xcm-api/src/auth/utils/escapeHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/escapeHtml.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeHtml } from './escapeHtml.js';
+
+describe('escapeHtml', () => {
+  it('should pass through plain text unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+
+  it('should pass through empty string unchanged', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('should escape ampersands', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  it('should escape angle brackets', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  it('should escape double quotes', () => {
+    expect(escapeHtml('"quoted"')).toBe('&quot;quoted&quot;');
+  });
+
+  it('should escape single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#39;s');
+  });
+
+  it('should prevent HTML link injection from issue #2008', () => {
+    const injectedLink =
+      '</span><a href="https://attacker.example">Review request</a><span>';
+    const escaped = escapeHtml(injectedLink);
+
+    // The escaped string must NOT contain an actual anchor tag
+    expect(escaped).not.toContain('<a href=');
+    expect(escaped).not.toContain('</a>');
+    // It should contain the text as escaped entities
+    expect(escaped).toContain('&lt;/span&gt;');
+    expect(escaped).toContain('&lt;a href=&quot;https://attacker.example&quot;&gt;');
+  });
+
+  it('should handle multiple special characters in a realistic reason', () => {
+    const malicious = '<img src=x onerror="alert(1)">';
+    const escaped = escapeHtml(malicious);
+    expect(escaped).toBe(
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;',
+    );
+    expect(escaped).not.toContain('<img');
+  });
+});

--- a/apps/xcm-api/src/auth/utils/escapeHtml.ts
+++ b/apps/xcm-api/src/auth/utils/escapeHtml.ts
@@ -1,0 +1,15 @@
+/**
+ * Escapes HTML special characters in a string to prevent HTML injection.
+ *
+ * Used for interpolating user-controlled values into email HTML templates.
+ *
+ * @param value - The string to escape
+ * @returns The HTML-escaped string
+ */
+export const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');

--- a/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.test.ts
@@ -34,4 +34,21 @@ describe('generateConfirmationEmailHtml', () => {
     expect(result).toContain('</body>');
     expect(result).toContain('Your request has been submitted successfully.');
   });
+
+  it('should escape HTML in user-controlled fields to prevent injection (#2008)', () => {
+    const injectedReason =
+      '</span><a href="https://attacker.example">Review request</a><span>';
+    const result = generateConfirmationEmailHtml(
+      'Title',
+      injectedReason,
+      '500',
+    );
+
+    // The injected anchor tag must NOT appear in the output
+    expect(result).not.toContain('<a href="https://attacker.example">');
+    expect(result).not.toContain('</a>');
+    // The dangerous characters must be escaped
+    expect(result).toContain('&lt;/span&gt;');
+    expect(result).toContain('&lt;a href=');
+  });
 });

--- a/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './escapeHtml.js';
+
 export const generateConfirmationEmailHtml = (
   title: string,
   reason: string,
@@ -104,7 +106,7 @@ export const generateConfirmationEmailHtml = (
     
       <!-- start preheader -->
       <div class="preheader" style="display: none; max-width: 0; max-height: 0; overflow: hidden; font-size: 1px; line-height: 1px; color: #fff; opacity: 0;">
-        ${title}
+        ${escapeHtml(title)}
       </div>
       <!-- end preheader -->
     
@@ -148,7 +150,7 @@ export const generateConfirmationEmailHtml = (
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
-                  <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">${title}</h1>
+                  <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">${escapeHtml(title)}</h1>
                 </td>
               </tr>
             </table>
@@ -182,8 +184,8 @@ export const generateConfirmationEmailHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${escapeHtml(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${escapeHtml(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->

--- a/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.test.ts
@@ -41,4 +41,22 @@ describe('generateNewHigherLimitRequestHtml', () => {
     expect(result).toContain('</body>');
     expect(result).toContain('New higher limit request for submitted:');
   });
+
+  it('should escape HTML in user-controlled fields to prevent injection (#2008)', () => {
+    const injectedLink =
+      '</span><a href="https://attacker.example">Review request</a><span>';
+    const result = generateNewHigherLimitRequestHtml(
+      'attacker@example.com',
+      'user-id',
+      injectedLink,
+      '500',
+    );
+
+    // The injected anchor tag must NOT appear in the output
+    expect(result).not.toContain('<a href="https://attacker.example">');
+    expect(result).not.toContain('</a>');
+    // The dangerous characters must be escaped
+    expect(result).toContain('&lt;/span&gt;');
+    expect(result).toContain('&lt;a href=');
+  });
 });

--- a/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './escapeHtml.js';
+
 export const generateNewHigherLimitRequestHtml = (
   userEmail: string,
   userId: string,
@@ -183,10 +185,10 @@ export const generateNewHigherLimitRequestHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${userEmail}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${userId}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${escapeHtml(userEmail)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${escapeHtml(userId)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${escapeHtml(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${escapeHtml(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->


### PR DESCRIPTION
## Bug

Fixes #2008

The XCM API's higher-request-limit form interpolated requester-controlled values directly into two HTML email templates without encoding them:

- `generateNewHigherLimitRequestHtml` — sends to configured maintainer recipients
- `generateConfirmationEmailHtml` — sends to the requester-supplied email address

`reason`, `requestedLimit`, `email`, `userId`, and `title` could break out of their surrounding `<span>` elements and inject rendered HTML, including attacker-chosen links, into emails sent from ParaSpell's trusted sender address.

## Reproduction (from bug report)

```ts
const injectedLink =
  '</span><a href="https://attacker.example">Review request</a><span>'

const html = generateNewHigherLimitRequestHtml(
  'attacker@example.com',
  'user-id',
  injectedLink,
  '500'
)

console.log(html.includes('<a href="https://attacker.example">'))
// true — before fix
```

## Fix

1. **New utility** (`escapeHtml.ts`): standard HTML entity encoding for `&`, `<`, `>`, `"`, `'`.
2. **`generateNewHigherLimitRequestHtml.ts`**: wrap `userEmail`, `userId`, `reason`, `requestedLimit` in `escapeHtml()`.
3. **`generateConfirmationEmailHtml.ts`**: wrap `title`, `reason`, `requestedLimit` in `escapeHtml()`.

## Tests

- `escapeHtml.test.ts`: 8 test cases covering plain text, empty string, each special character, the exact injection payload from the bug report, and a realistic `<img onerror>` XSS attempt.
- `generateNewHigherLimitRequestHtml.test.ts`: added test verifying the injection payload from the bug report is neutralized.
- `generateConfirmationEmailHtml.test.ts`: added the same injection-prevention test.