### PR TITLE
[Bug bounty] Fix: Direct WebSocket Builder configuration breaks swap operations (#2026)

### DIFF
--- a/packages/sdk-core/src/utils/swap/swapUtils.test.ts
+++ b/packages/sdk-core/src/utils/swap/swapUtils.test.ts
@@ -226,6 +226,24 @@ describe('swapUtils', () => {
       )
     })
 
+    it('should accept a string WS URL without throwing (bug bounty #2026)', () => {
+      vi.mocked(guards.isConfig).mockReturnValue(false)
+
+      // Before the fix, typeof 'string' && Array.isArray() was always false,
+      // so a valid wss:// URL would throw UnsupportedOperationError
+      const config = 'wss://rpc.polkadot.io'
+
+      expect(() => convertBuilderConfig(config)).not.toThrow()
+    })
+
+    it('should accept a string array of WS URLs without throwing (bug bounty #2026)', () => {
+      vi.mocked(guards.isConfig).mockReturnValue(false)
+
+      const config = ['wss://rpc.polkadot.io', 'wss://rpc2.polkadot.io']
+
+      expect(() => convertBuilderConfig(config)).not.toThrow()
+    })
+
     it('should return rest without apiOverrides when apiOverrides is undefined in config', () => {
       vi.mocked(guards.isConfig).mockReturnValue(true)
 

--- a/packages/sdk-core/src/utils/swap/swapUtils.ts
+++ b/packages/sdk-core/src/utils/swap/swapUtils.ts
@@ -57,7 +57,7 @@ export const convertBuilderConfig = <TApi>(
     }
   }
 
-  const isWsUrl = typeof config === 'string' && Array.isArray(config)
+  const isWsUrl = typeof config === 'string' || Array.isArray(config)
   if (!isWsUrl) {
     throw new UnsupportedOperationError('Swap module does not support API client override')
   }


### PR DESCRIPTION
## Bug

Fixes #2026

The swap path rejected a top-level WebSocket URL passed to `Builder`, even though a WebSocket URL is a documented supported `Builder` input.

`convertBuilderConfig` calculated:

```ts
const isWsUrl = typeof config === 'string' && Array.isArray(config)
```

No JavaScript value can be both a string **and** an array, so this was always `false`. A valid `wss://...` URL unconditionally threw `UnsupportedOperationError('Swap module does not support API client override')` before a quote or swap route could be built.

## Root Cause

```ts
// BUG: && makes this always false — no value is both a string AND an array
const isWsUrl = typeof config === 'string' && Array.isArray(config)
```

The intended predicate is evidently a string **or** an array of strings. The existing `isUrl` helper at line 17 and `resolveChainApi` already handle both forms with `||`.

## Fix

One-character fix: change `&&` to `||`.

```ts
const isWsUrl = typeof config === 'string' || Array.isArray(config)
```

## Tests

Added two tests:
- `should accept a string WS URL without throwing` — verifies `convertBuilderConfig('wss://rpc.polkadot.io')` does not throw.
- `should accept a string array of WS URLs without throwing` — verifies the array form also works.

Both tests would have failed before the fix.