### PR TITLE
[Bug bounty] Fix: Dedot signAndSubmitFinalized reports failed extrinsics as successful (#2011)

### DIFF
--- a/packages/sdk-dedot/src/DedotApi.test.ts
+++ b/packages/sdk-dedot/src/DedotApi.test.ts
@@ -1878,5 +1878,39 @@ describe("DedotApi", () => {
         dedotApi.signAndSubmitFinalized(mockTx, "//Alice"),
       ).rejects.toThrow("finalization failed");
     });
+
+    it("should throw when the finalized result contains a dispatchError (#2011)", async () => {
+      const mockTxHash = "0xfailed";
+      const mockTx = {
+        signAndSend: vi.fn().mockReturnValue({
+          untilFinalized: vi.fn().mockResolvedValue({
+            txHash: mockTxHash,
+            dispatchError: {
+              type: "Module",
+              value: { index: 5, error: 2 },
+            },
+          }),
+        }),
+      } as unknown as TDedotExtrinsic;
+
+      await expect(
+        dedotApi.signAndSubmitFinalized(mockTx, "//Alice"),
+      ).rejects.toThrow(/dispatch error/);
+    });
+
+    it("should resolve when dispatchError is undefined (#2011)", async () => {
+      const mockTxHash = "0xsuccess";
+      const mockTx = {
+        signAndSend: vi.fn().mockReturnValue({
+          untilFinalized: vi.fn().mockResolvedValue({
+            txHash: mockTxHash,
+            dispatchError: undefined,
+          }),
+        }),
+      } as unknown as TDedotExtrinsic;
+
+      const result = await dedotApi.signAndSubmitFinalized(mockTx, "//Alice");
+      expect(result).toBe(mockTxHash);
+    });
   });
 });

--- a/packages/sdk-dedot/src/DedotApi.ts
+++ b/packages/sdk-dedot/src/DedotApi.ts
@@ -942,6 +942,13 @@ class DedotApi<TCustomChain extends string = never> extends PolkadotApi<
   ): Promise<string> {
     const account = isSenderSigner(sender) ? sender : createKeyringPair(sender);
     const result = await tx.signAndSend(account).untilFinalized();
+
+    if (result.dispatchError) {
+      throw new Error(
+        `Extrinsic failed at finalization with dispatch error: ${JSON.stringify(result.dispatchError)}`,
+      );
+    }
+
     return result.txHash;
   }
 }


### PR DESCRIPTION
## Bug

Fixes #2011

The Dedot backend waited for finalization but returned the transaction hash without checking the finalized result's `dispatchError`. A finalized extrinsic that failed at runtime was reported as successful.

## Affected Code

`packages/sdk-dedot/src/DedotApi.ts`, in `signAndSubmitFinalized`:

```ts
const result = await tx.signAndSend(account).untilFinalized();
return result.txHash;  // ← no check for dispatchError
```

Dedot's `untilFinalized()` resolves a finalized `SubmittableResult`; a runtime failure is represented by `dispatchError`, not necessarily by a rejected promise. The PAPI and Polkadot.js backends already reject dispatch errors, but Dedot silently returned a hash.

This also affected SWAP route execution: `executeRouterPlan` treats a resolved hash as success, may continue dependent route steps, and can emit `COMPLETED` even though the extrinsic failed.

## Fix

```ts
const result = await tx.signAndSend(account).untilFinalized();

if (result.dispatchError) {
  throw new Error(
    `Extrinsic failed at finalization with dispatch error: ${JSON.stringify(result.dispatchError)}`,
  );
}

return result.txHash;
```

## Tests

Added two test cases:
- `should throw when the finalized result contains a dispatchError` — mocks `untilFinalized()` returning `{ txHash, dispatchError: { type: 'Module', value: { index: 5, error: 2 } } }` and verifies the method throws.
- `should resolve when dispatchError is undefined` — verifies normal success path still works when `dispatchError` is explicitly `undefined`.

The existing tests (`should resolve with txHash on finalized`, `should propagate errors from untilFinalized`) continue to pass unchanged.