### PR TITLE
fix(pjs): fix relay-chain Here junction casing in dry-run and update test suite (#2051)

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -1392,7 +1392,7 @@ describe('PolkadotJsApi', () => {
         asset: dotAsset,
         weight: { refTime: 1000n, proofSize: 2000n },
         forwardedXcms: expect.any(Object),
-        destParaId: undefined
+        destParaId: 0
       })
     })
 

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -441,7 +441,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 
@@ -697,7 +697,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.Here ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 


### PR DESCRIPTION
Resolves #2051.

Fixes relay-chain Here junction casing in packages/sdk-pjs/src/PolkadotJsApi.ts dry-run methods and updates test suite in PolkadotJsApi.test.ts.

Signed-off-by: jihadMo <jihadMo@users.noreply.github.com>