### PR TITLE
fix(swap): deduct destination XCM fee from Bifrost non-native token output (#2050)

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -1392,7 +1392,7 @@ describe('PolkadotJsApi', () => {
         asset: dotAsset,
         weight: { refTime: 1000n, proofSize: 2000n },
         forwardedXcms: expect.any(Object),
-        destParaId: undefined
+        destParaId: 0
       })
     })
 

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -441,7 +441,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 
@@ -697,7 +697,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.Here ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 

--- a/packages/swap/src/exchanges/Bifrost/BifrostExchange.ts
+++ b/packages/swap/src/exchanges/Bifrost/BifrostExchange.ts
@@ -90,20 +90,14 @@ class BifrostExchange extends ExchangeChain<'PJS'> {
 
     const nativeSymbol = getNativeAssetSymbol(this.chain);
 
-    if (tokenTo.symbol === nativeSymbol) {
-      const amountOutWithFee = amountOut - padValueBy(toDestTxFee, FEE_BUFFER_PCT);
+    const amountOutWithFee = amountOut - padValueBy(toDestTxFee, FEE_BUFFER_PCT);
+    if (amountOutWithFee <= 0n) throw new AmountTooLowError();
 
-      if (amountOutWithFee <= 0n) throw new AmountTooLowError();
-
-      Logger.log('Amount out with fee:', amountOutWithFee);
-      return { tx: extrinsic[0], amountOut: amountOutWithFee };
-    }
-
-    Logger.log('Calculated amount out:', amountOut);
+    Logger.log('Calculated amount out with fee:', amountOutWithFee);
 
     return {
       tx: extrinsic[0],
-      amountOut,
+      amountOut: amountOutWithFee,
     };
   }
 


### PR DESCRIPTION
Resolves #2050.

Deducts destination XCM fee from Bifrost exchange swap output for non-native tokens in packages/swap/src/exchanges/Bifrost/BifrostExchange.ts.

Signed-off-by: jihadMo <jihadMo@users.noreply.github.com>