### PR TITLE
fix: HTML-encode dynamic values in higher-limit email templates

### DIFF
--- a/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.test.ts
@@ -34,4 +34,21 @@ describe('generateConfirmationEmailHtml', () => {
     expect(result).toContain('</body>');
     expect(result).toContain('Your request has been submitted successfully.');
   });
+
+  it('should encode HTML metacharacters in reason and requestedLimit', () => {
+    const injectedLink =
+      '</span><a href="https://attacker.example">Review request</a><span>';
+
+    const result = generateConfirmationEmailHtml(
+      'Request Submission Confirmation',
+      injectedLink,
+      '500',
+    );
+
+    expect(result).not.toContain('<a href="https://attacker.example">');
+    expect(result).toContain('&lt;/span&gt;&lt;a href=&quot;https://attacker.example&quot;&gt;');
+    expect(result).toContain('&lt;/a&gt;&lt;span&gt;');
+    expect(result).toContain('<html>');
+    expect(result).toContain('</html>');
+  });
 });

--- a/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateConfirmationEmailHtml.ts
@@ -1,3 +1,5 @@
+import { htmlEncode } from './htmlEncode.js';
+
 export const generateConfirmationEmailHtml = (
   title: string,
   reason: string,
@@ -182,8 +184,8 @@ export const generateConfirmationEmailHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${htmlEncode(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${htmlEncode(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->

--- a/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.test.ts
+++ b/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.test.ts
@@ -41,4 +41,24 @@ describe('generateNewHigherLimitRequestHtml', () => {
     expect(result).toContain('</body>');
     expect(result).toContain('New higher limit request for submitted:');
   });
+
+  it('should encode HTML metacharacters in all fields', () => {
+    const injectedLink =
+      '</span><a href="https://attacker.example">Review request</a><span>';
+
+    const result = generateNewHigherLimitRequestHtml(
+      'attacker@example.com',
+      '<script>alert(1)</script>',
+      injectedLink,
+      '500',
+    );
+
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(result).not.toContain('<a href="https://attacker.example">');
+    expect(result).toContain('&lt;/span&gt;&lt;a href=&quot;https://attacker.example&quot;&gt;');
+    expect(result).toContain('&lt;/a&gt;&lt;span&gt;');
+    expect(result).toContain('<html>');
+    expect(result).toContain('</html>');
+  });
 });

--- a/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
+++ b/apps/xcm-api/src/auth/utils/generateNewHigherLimitRequestHtml.ts
@@ -1,3 +1,5 @@
+import { htmlEncode } from './htmlEncode.js';
+
 export const generateNewHigherLimitRequestHtml = (
   userEmail: string,
   userId: string,
@@ -183,10 +185,10 @@ export const generateNewHigherLimitRequestHtml = (
               <!-- start copy -->
               <tr>
                 <td align="left" bgcolor="#ffffff" style="padding: 24px; padding-top: 0; padding-bottom: 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 16px;">
-                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${userEmail}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${userId}</span></p>
-                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${reason}</span></p>
-                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${requestedLimit}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User Email: <span style="font-weight: bold;">${htmlEncode(userEmail)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">User ID: <span style="font-weight: bold;">${htmlEncode(userId)}</span></p>
+                  <p style="margin: 0; margin-bottom: 12px;">Reason for Higher Limit: <span style="font-weight: bold;">${htmlEncode(reason)}</span></p>
+                  <p style="margin: 0;">Requested Requests Per Minute: <span style="font-weight: bold;">${htmlEncode(requestedLimit)}</span></p>
                 </td>
               </tr>
               <!-- end copy -->

--- a/apps/xcm-api/src/auth/utils/htmlEncode.ts
+++ b/apps/xcm-api/src/auth/utils/htmlEncode.ts
@@ -1,0 +1,18 @@
+/*
+ * Author: RawNuke
+ * Copyright (c) 2026 RawNuke. All rights reserved.
+ */
+
+/**
+ * Encode HTML special characters in a string.
+ *
+ * Encodes &, <, >, ", and '.
+ * Use this function before you insert a value into an HTML document.
+ */
+export const htmlEncode = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2008

---

## 🛠️ Description of the Fix

- Bug description: The XCM API higher-request-limit form interpolated requester-controlled values (reason, requestedLimit, email, userId) directly into HTML email templates without encoding, allowing HTML injection.
- Fix summary: Added an htmlEncode utility that encodes `&`, `<`, `>`, `"`, `'` and applied it to every dynamic value in both `generateNewHigherLimitRequestHtml` and `generateConfirmationEmailHtml`. Tests added with the exact attack vector from the bug report.

---

## ✅ Contributor Eligibility

- [ ] My GitHub account's commit history is at least 6 months old.
- [ ] I have set an on-chain identity on the Polkadot People Chain for my AssetHub address and requested a registrar judgement of at least Reasonable.
- [x] Every commit in this PR is signed and includes Signed-off-by and AI-Assisted-By trailers.
- [x] I disclose that AI tools (Claude via opencode) assisted with this fix. I understand and can explain the resulting code.
- [ ] This fix was authored and reviewed by a human — AI assistance was used for scaffold and encoding logic.
- [x] I will respond to maintainer review questions with specific, on-topic answers within 5 days.
- [ ] I understand 🔴 High complexity fixes may require a brief live chat/call walkthrough before payout.
- [ ] This is the only bug bounty issue I currently have reserved.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 🧩 Additional Notes

The fix is minimal and focused: a single utility function applied to both template files. The encoding covers the five HTML special characters (`&`, `<`, `>`, `"`, `'`) and is applied before template interpolation so encoded values cannot break out of the surrounding span elements.