### PR TITLE
fix(sdk-pjs): fix Here junction detection in dry-run forwarding

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -1392,7 +1392,7 @@ describe('PolkadotJsApi', () => {
         asset: dotAsset,
         weight: { refTime: 1000n, proofSize: 2000n },
         forwardedXcms: expect.any(Object),
-        destParaId: undefined
+        destParaId: 0
       })
     })
 
@@ -1674,7 +1674,7 @@ describe('PolkadotJsApi', () => {
         asset: feeAsset,
         weight: { refTime: 555n, proofSize: 666n },
         forwardedXcms: expectedForwarded,
-        destParaId: undefined
+        destParaId: 0
       })
 
       paymentInfoSpy.mockRestore()
@@ -2121,7 +2121,8 @@ describe('PolkadotJsApi', () => {
           refTime: 111n,
           proofSize: 222n
         },
-        forwardedXcms: expect.any(Object)
+        forwardedXcms: expect.any(Object),
+        destParaId: 0
       })
     })
 

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -441,7 +441,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 
@@ -697,7 +697,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.Here ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.Here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 


### PR DESCRIPTION
## 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2051

---

## 🛠️ Description of the Fix

- Bug description: PJS SDK dry-run XCM forwarding uses wrong key casing when checking for Here junctions (relay-chain destinations), causing it to never detect them.
- Fix summary: Fixed two bugs:
  1. **Line 444**: `i.here` (lowercase) \→ `i.Here` (uppercase) \— the property didn't exist so `undefined === null` was false
  2. **Line 700**: `i.Here ?` (truthiness) \→ `i.Here === null ? ` (strict null check) \— since `i.Here` is `null` (falsy), the ternary always fell through
  Both now correctly detect `{ Here: null }` junctions and return `destParaId: 0` for relay-chain destinations, consistent with the Dedot backend.

---

## ✅ Contributor Eligibility

- [ ] My GitHub account's commit history is at least 6 months old.
- [ ] I have set an on-chain identity on the Polkadot People Chain for my AssetHub address and requested a registrar judgement of at least `Reasonable`.
- [ ] Every commit in this PR is signed (`-S`) and includes `Signed-off-by` and `AI-Assisted-By: <tool name(s)>` trailers.
- [x] I disclose any AI tools used to help write this fix. AI-Assisted-By: opencode (Claude DeepSeek V4 Pro).
- [ ] This fix was authored and reviewed by a human — not opened autonomously by an AI agent.
- [x] I will respond to maintainer review questions with specific, on-topic answers within 5 days.
- [ ] I understand 🔴 High complexity fixes may require a brief live chat/call walkthrough before payout.
- [ ] This is the only bug bounty issue I currently have reserved.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective (if applicable). Updated 3 test assertions that encoded the bug to expect `destParaId: 0`.
- [x] I have updated the documentation where necessary. N/A — no documentation changes needed.
- [x] I have verified the fix does not introduce new issues. All 99 tests pass (`vitest run src/PolkadotJsApi.test.ts`).

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `INSERT_ADDRESS_HERE`

---

## 🧩 Additional Notes

AI tools used: opencode (Claude DeepSeek V4 Pro) for code analysis, fix implementation, and test verification. All changes have been tested and verified to pass the full test suite.