### PR TITLE
fix: Use lowercase 'here' key in PJS getDryRunXcm to match toJSON output

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -1244,7 +1244,7 @@ describe('PolkadotJsApi', () => {
     const hereForwarded = [
       [
         {
-          v4: { parents: 0, interior: { Here: null } }
+          v4: { parents: 0, interior: { here: null } }
         }
       ]
     ] as unknown as object[]
@@ -1392,7 +1392,7 @@ describe('PolkadotJsApi', () => {
         asset: dotAsset,
         weight: { refTime: 1000n, proofSize: 2000n },
         forwardedXcms: expect.any(Object),
-        destParaId: undefined
+        destParaId: 0
       })
     })
 
@@ -1674,7 +1674,7 @@ describe('PolkadotJsApi', () => {
         asset: feeAsset,
         weight: { refTime: 555n, proofSize: 666n },
         forwardedXcms: expectedForwarded,
-        destParaId: undefined
+        destParaId: 0
       })
 
       paymentInfoSpy.mockRestore()

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -697,7 +697,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.Here ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 


### PR DESCRIPTION
## Fix for #2051

The PJS SDK serializes `Here` as lowercase `here` in `toJSON()`. The code in `getDryRunXcm` was checking `i.Here === null` instead of `i.here === null`, causing the `destParaId` to never be correctly detected for the `Here` junction case.

### Changes
- Changed `i.Here === null` → `i.here === null` in `PolkadotJsApi.ts`
- Updated test fixtures from `{ Here: null }` → `{ here: null }`
- Updated test assertions: `destParaId: undefined` → `destParaId: 0` (correct value for `here` junction)

### Testing
- [x] Unit tests updated and passing locally

Closes #2051

@michaeldev5