### PR TITLE
fix: Respect isPrefixed in accountToHex for hex inputs

### DIFF
--- a/packages/sdk-dedot/src/DedotApi.ts
+++ b/packages/sdk-dedot/src/DedotApi.ts
@@ -132,7 +132,7 @@ class DedotApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address;
+    if (isHex(address)) return isPrefixed ? address : address.slice(2);
     const uint8Array = decodeAddress(address);
     const hex = u8aToHex(uint8Array);
     return isPrefixed ? hex : hex.slice(2);

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -90,7 +90,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address
+    if (isHex(address)) return isPrefixed ? address : address.slice(2)
     const uint8Array = decodeAddress(address)
     return u8aToHex(uint8Array, -1, isPrefixed)
   }

--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -161,7 +161,7 @@ class PapiApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address
+    if (isHex(address)) return isPrefixed ? address : address.slice(2)
     const hex = toHex(AccountId().enc(address))
     return isPrefixed ? hex : hex.slice(2)
   }


### PR DESCRIPTION
## Fix for #2060

`accountToHex(address, isPrefixed)` ignored the `isPrefixed` argument when the input was already a hex string, always returning the `0x`-prefixed form. This broke `getDestinationLocation.ts` which calls `accountToHex(address, false)` expecting an **un-prefixed** hex string.

### Changes
- **3 SDK backends** updated (PapiApi, PolkadotJsApi, DedotApi):
  `if (isHex(address)) return isPrefixed ? address : address.slice(2)`
- Consistent with the non-hex code path which already respects `isPrefixed`

### Testing
- [x] Verified no existing test combines hex input + `isPrefixed=false`
- [x] `isHex()` requires `0x` prefix, so `slice(2)` reliably strips exactly the prefix

Closes #2060

@michaeldev5