### PR TITLE
fix: Clamp parents field to max 8 in XCM Analyser LocationSchema

### DIFF
--- a/packages/xcm-analyser/src/schema.test.ts
+++ b/packages/xcm-analyser/src/schema.test.ts
@@ -448,11 +448,11 @@ describe('LocationSchema', () => {
   });
 
   it('should pass with valid parents (string with comma) and Interior { Here: null }', () => {
-    const data = { parents: '1,000', interior: { Here: null } };
+    const data = { parents: '0,008', interior: { Here: null } };
     const result = LocationSchema.safeParse(data);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({ parents: '1000', interior: { Here: null } });
+      expect(result.data).toEqual({ parents: '0008', interior: { Here: null } });
     }
   });
 
@@ -473,6 +473,12 @@ describe('LocationSchema', () => {
 
   it('should fail if parents is invalid', () => {
     const data = { parents: 'abc', interior: 'Here' };
+    const result = LocationSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject parents > 8 (DoS protection)', () => {
+    const data = { parents: '1000', interior: 'Here' };
     const result = LocationSchema.safeParse(data);
     expect(result.success).toBe(false);
   });

--- a/packages/xcm-analyser/src/schema.ts
+++ b/packages/xcm-analyser/src/schema.ts
@@ -134,6 +134,9 @@ export const InteriorSchema = z.union(
 );
 
 export const LocationSchema = z.object({
-  parents: StringOrNumber,
+  parents: StringOrNumber.refine(
+    (val) => Number(val) >= 0 && Number(val) <= 8,
+    { message: 'parents must be between 0 and 8' }
+  ),
   interior: InteriorSchema,
 });


### PR DESCRIPTION
## Fix for #2061

The `parents` field in `LocationSchema` accepted unbounded numeric strings. Since `convert.ts` does `'../'.repeat(parents)`, a value like `89,000,000` allocates ~255 MB — memory-exhaustion DoS via the public XCM Analyser API.

### Changes
- Added `.refine((val) => Number(val) >= 0 && Number(val) <= 8)` to the `parents` field in `LocationSchema`
- 8 is the maximum meaningful value for XCM parents (real-world: 0, 1, or 2)
- Updated comma-formatted test to use in-range value `'0,008'`
- Added test verifying `parents > 8` is rejected

### Testing
- [x] Existing `convert.test.ts` tests use parents ≤ 3 — unaffected
- [x] Updated `schema.test.ts` comma test to use value ≤ 8
- [x] Added new rejection test

Closes #2061

@michaeldev5