### PR TITLE
fix: Include swapChain.dryRunError in getRouterFees error coalescing

### DIFF
--- a/packages/swap/src/transfer/getRouterFees.ts
+++ b/packages/swap/src/transfer/getRouterFees.ts
@@ -103,7 +103,7 @@ export const getRouterFees = async <
     ...(!origin && !destination && { fee: 0n }),
   };
 
-  const dryRunError = sendingChain?.dryRunError ?? receivingChain?.dryRunError;
+  const dryRunError = sendingChain?.dryRunError ?? swapChain?.dryRunError ?? receivingChain?.dryRunError;
 
   return {
     success: !dryRunError,


### PR DESCRIPTION
## Fix for #2062

`getRouterFees.ts:106` coalesced `dryRunError` from `sendingChain` and `receivingChain` but **omitted** `swapChain`. The `swapChain` object (from `getSwapFee`) carries its own `dryRunError` field (type `TConditionalXcmFeeDetail`). When origin and destination are the same chain as the exchange, `swapChain` is the only fee source — its errors were silently dropped.

### Changes
- Added `?? swapChain?.dryRunError` to the nullish-coalescing chain
- Priority: `sendingChain → swapChain → receivingChain`

### Testing
- [x] Type-verified: `TConditionalXcmFeeDetail` has `dryRunError` on both success/error arms
- [x] Existing tests: swap mock has no `dryRunError` (undefined) — success-path assertions unchanged
- [x] Failure tests set `sendingChain.dryRunError` (wins first) — unchanged

Closes #2062

@michaeldev5