### PR TITLE
fix: Guard releaseClient with client check in Snowbridge transfer

### DIFF
--- a/packages/evm-snowbridge/src/buildSnowbridgeTransfer.ts
+++ b/packages/evm-snowbridge/src/buildSnowbridgeTransfer.ts
@@ -82,7 +82,7 @@ export const buildSnowbridgeTransfer = async <
     chainId: environment.ethChainId
   }
 
-  releaseClient(ETHEREUM_WS_URLS)
+  if (!client) releaseClient(ETHEREUM_WS_URLS)
 
   return {
     tx,


### PR DESCRIPTION
## Fix for #2063

`buildSnowbridgeTransfer` calls `leaseClient()` only when no `client` is provided by the caller (`client ?? leaseClient(...)`). But `releaseClient()` was called **unconditionally** at line 85, even when the caller provided its own client. This spurious release decrements a refcount that was never incremented, corrupting the shared Ethereum WS pool under concurrency.

### Changes
- `releaseClient(ETHEREUM_WS_URLS)` → `if (!client) releaseClient(ETHEREUM_WS_URLS)`
- Only releases the client when we actually leased it

### Testing
- [x] Verified `client?: PublicClient` is the optional 2nd parameter
- [x] `leaseClient` does `refs += 1`, `releaseClient` does `refs -= 1` — now balanced
- [x] Existing test for caller-supplied client never asserted on `releaseClient` — no regression

Closes #2063

@michaeldev5