### PR TITLE
fix: Use safeParse instead of parse in findLocationInObject

### DIFF
--- a/packages/xcm-analyser/src/converter/convert.test.ts
+++ b/packages/xcm-analyser/src/converter/convert.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { ZodError } from 'zod';
 
 import { type Location } from '../types';
 import { convertLocationToUrl, convertXCMToUrls } from './convert';
@@ -308,11 +307,10 @@ describe('convert', () => {
       },
     ];
 
-    const t = () => {
-      convertXCMToUrls(xcmCallArguments);
-    };
+    const result = convertXCMToUrls(xcmCallArguments);
 
-    expect(t).toThrow(ZodError);
+    // Invalid location (X2 with 3 elements) is gracefully skipped, not thrown
+    expect(result).toStrictEqual([]);
   });
 
   it('convert location to URL with plurality', () => {

--- a/packages/xcm-analyser/src/utils/utils.ts
+++ b/packages/xcm-analyser/src/utils/utils.ts
@@ -56,7 +56,8 @@ export function findLocationInObject(obj: unknown): Location | null {
 
   function searchObject(value: unknown): Location | null {
     if (hasSpecificKeys(value)) {
-      return LocationSchema.parse(value);
+      const result = LocationSchema.safeParse(value);
+      return result.success ? result.data : null;
     } else if (typeof value === 'object' && value !== null) {
       for (const key of Object.keys(value)) {
         const result = searchObject((value as Record<string, unknown>)[key]);


### PR DESCRIPTION
## Fix for #2064

`findLocationInObject` used `LocationSchema.parse()` which **throws** `ZodError` on any validation failure. Since `hasSpecificKeys()` only checks for key presence (not validity), any object with `parents` and `interior` keys that has an unsupported junction type crashes the entire XCM conversion.

### Changes
- Replaced `LocationSchema.parse(value)` with `LocationSchema.safeParse(value)`
- Returns `result.success ? result.data : null` — gracefully skips invalid locations
- Updated test: invalid X2-with-3-elements now returns `[]` instead of throwing
- Removed unused `ZodError` import from test

### Testing
- [x] Function return type is `Location | null` — `null` on parse failure is consistent
- [x] Caller (`convert.ts:52`) handles `null` gracefully (returns `[]`)
- [x] Updated `convert.test.ts` to expect `[]` instead of `toThrow(ZodError)`

Closes #2064

@michaeldev5