### PR TITLE
fix: Pad paraId hex to fixed 8 chars in getDestinationLocation

### DIFF
--- a/packages/evm/src/xTokens/getDestinationLocation.test.ts
+++ b/packages/evm/src/xTokens/getDestinationLocation.test.ts
@@ -35,8 +35,8 @@ describe('getDestinationLocation', () => {
 
     const [paraIdHex, finalAddress] = result[1] as [string, string]
 
-    // paraId=2000 => 0x7d0 => "0x00000007d0"
-    expect(paraIdHex).toBe('0x00000007d0')
+    // paraId=2000 => 0x7d0 => "0x000007d0"
+    expect(paraIdHex).toBe('0x000007d0')
 
     // accountType='01', addressHex='abc123', '00' at the end
     expect(finalAddress).toBe('0x01abc12300')
@@ -54,7 +54,8 @@ describe('getDestinationLocation', () => {
 
     const [paraIdHex, finalAddress] = result[1] as [string, string]
 
-    expect(paraIdHex).toBe('0x0000000bb8')
+    // paraId=3000 => 0xbb8 => "0x00000bb8"
+    expect(paraIdHex).toBe('0x00000bb8')
 
     expect(finalAddress).toBe('0x03deadbeef00')
   })

--- a/packages/evm/src/xTokens/getDestinationLocation.ts
+++ b/packages/evm/src/xTokens/getDestinationLocation.ts
@@ -18,5 +18,5 @@ export const getDestinationLocation = <TApi, TRes, TSigner, TCustomChain extends
 
   const paraId = getParaId(destination)
 
-  return [1, paraId ? [`0x0000000${paraId.toString(16)}`, acc] : [acc]]
+  return [1, paraId ? [`0x${paraId.toString(16).padStart(8, '0')}`, acc] : [acc]]
 }


### PR DESCRIPTION
## Fix for #2065

The template `0x0000000${paraId.toString(16)}` prepends exactly 7 zeros, but `paraId.toString(16)` is variable length. This produces invalid hex for certain paraId ranges:

| paraId range | hex length after `0x` | valid? |
|---|---|---|
| 0–15 | 8 | ✓ (accidentally correct) |
| 16–255 | 9 | ❌ **odd-length invalid hex** |
| 256–4095 | 10 | ❌ wrong byte width |
| 4096–65535 | 11 | ❌ wrong byte width |

### Changes
- Replaced with `0x${paraId.toString(16).padStart(8, '0')}` — always produces 8 hex chars (4 bytes / u32)
- Updated 2 test assertions to expect correct padded values

### Testing
- [x] paraId=2000: `0x7d0` → `0x000007d0` (was `0x00000007d0` — 9 chars, invalid)
- [x] paraId=3000: `0xbb8` → `0x00000bb8` (was `0x0000000bb8` — 10 chars, invalid)

Closes #2065

@michaeldev5