### PR TITLE
fix(sdk): accountToHex strips 0x prefix when isPrefixed=false for hex inputs

### DIFF
--- a/packages/sdk-dedot/src/DedotApi.test.ts
+++ b/packages/sdk-dedot/src/DedotApi.test.ts
@@ -224,6 +224,13 @@ describe("DedotApi", () => {
       const result = dedotApi.accountToHex("0xabcdef");
       expect(result).toBe("0xabcdef");
     });
+
+    it("strips the 0x prefix when isPrefixed=false and input is already hex", async () => {
+      const { isHex } = await import("dedot/utils");
+      vi.mocked(isHex).mockReturnValueOnce(true);
+      const result = dedotApi.accountToHex("0xabcdef", false);
+      expect(result).toBe("abcdef");
+    });
   });
 
   describe("accountToUint8a", () => {

--- a/packages/sdk-dedot/src/DedotApi.ts
+++ b/packages/sdk-dedot/src/DedotApi.ts
@@ -132,7 +132,7 @@ class DedotApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address;
+    if (isHex(address)) return isPrefixed ? address : address.slice(2);
     const uint8Array = decodeAddress(address);
     const hex = u8aToHex(uint8Array);
     return isPrefixed ? hex : hex.slice(2);

--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -299,6 +299,12 @@ describe('PolkadotJsApi', () => {
       const result = polkadotApi.accountToHex(address, true)
       expect(result).toBe('0x88ca48e3e1d0f1c50bd6b504e1312d21f5bd45ed147e3c30c77eb5e4d63bdc63')
     })
+
+    it('should strip the 0x prefix when isPrefixed=false and input is already hex', () => {
+      const address = '0xf24ff3a9cf04c71dbc94d0b566f7a27b94566cac'
+      const result = polkadotApi.accountToHex(address, false)
+      expect(result).toBe('f24ff3a9cf04c71dbc94d0b566f7a27b94566cac')
+    })
   })
 
   describe('accountToUint8a', () => {

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -90,7 +90,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address
+    if (isHex(address)) return isPrefixed ? address : address.slice(2)
     const uint8Array = decodeAddress(address)
     return u8aToHex(uint8Array, -1, isPrefixed)
   }

--- a/packages/sdk/src/PapiApi.test.ts
+++ b/packages/sdk/src/PapiApi.test.ts
@@ -1021,6 +1021,12 @@ describe('PapiApi', () => {
       expect(spy).toHaveBeenCalledWith(account, false)
       expect(result).toBe('1234567890abcdef')
     })
+
+    it('should strip the 0x prefix when isPrefixed=false and input is already hex', () => {
+      const address = '0xf24ff3a9cf04c71dbc94d0b566f7a27b94566cac'
+      const result = papiApi.accountToHex(address, false)
+      expect(result).toBe('f24ff3a9cf04c71dbc94d0b566f7a27b94566cac')
+    })
   })
 
   describe('accountToUint8a', () => {

--- a/packages/sdk/src/PapiApi.ts
+++ b/packages/sdk/src/PapiApi.ts
@@ -161,7 +161,7 @@ class PapiApi<TCustomChain extends string = never> extends PolkadotApi<
   }
 
   accountToHex(address: string, isPrefixed = true) {
-    if (isHex(address)) return address
+    if (isHex(address)) return isPrefixed ? address : address.slice(2)
     const hex = toHex(AccountId().enc(address))
     return isPrefixed ? hex : hex.slice(2)
   }


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2060

---

## 🛠️ Description of the Fix

- **Bug description:** `accountToHex(address, isPrefixed)` ignored `isPrefixed` when the input was already a hex string, so `getDestinationLocation` (which builds the EVM destination as `0x${accountType}${addressHex}00` after calling `accountToHex(address, false)`) produced invalid hex such as `0x030xf24ff3...00` (double `0x`) → `encodeFunctionData` threw for hex EVM recipients.
- **Fix summary:** In all three backends (`PapiApi.ts`, `PolkadotJsApi.ts`, `DedotApi.ts`), hex inputs now respect `isPrefixed`: `if (isHex(address)) return isPrefixed ? address : address.slice(2)`. Non-hex inputs are unchanged.

**Regression tests** added per backend with a real hex EVM address + `isPrefixed=false`:
- `packages/sdk/src/PapiApi.test.ts`
- `packages/sdk-pjs/src/PolkadotJsApi.test.ts`
- `packages/sdk-dedot/src/DedotApi.test.ts`

**Test results (local):** `sdk` 237 passed · `sdk-pjs` 137 passed · `sdk-dedot` 170 passed.

---

## ✅ Contributor Eligibility

- [x] My GitHub account's commit history is at least 6 months old. (account created 2018-09-25)
- [ ] I have set an on-chain identity on the Polkadot People Chain for my AssetHub address and requested a registrar judgement of at least `Reasonable` (verifiable via [Subscan](https://people-polkadot.subscan.io/)).
- [ ] Every commit in this PR is signed (`-S`) and includes `Signed-off-by` and `AI-Assisted-By: <tool name(s)>` (or `AI-Assisted-By: None`) trailers.
- [x] I disclose any AI tools used to help write this fix, and I understand and can explain/defend the resulting code myself.
- [ ] This fix was authored and reviewed by a human — not opened autonomously by an AI agent.
- [x] I will respond to maintainer review questions with specific, on-topic answers within 5 days.
- [ ] I understand 🔴 High complexity fixes may require a brief live chat/call walkthrough before payout.
- [x] This is the only bug bounty issue I currently have reserved.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the documentation where necessary. (not needed — one-line behavioral fix)
- [x] I have verified the fix does not introduce new issues. (full local test suite green)

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `5G9iaFtijpT9JmzgxtfjYj3KybsYXnbSozXW1qZBoGrHG1u4`

---

## 🧩 Additional Notes

- **AI disclosure:** this fix was developed with assistance from an AI agent (Hermes Agent, per the `AI-Assisted-By` trailer on the commit); the owner (Dinh Truong) directed and reviewed the change and can explain/defend the code. The "authored by a human, not opened autonomously by an AI agent" checkbox is left unchecked to remain fully honest about the assistance.
- **Commit signature:** commits carry `Signed-off-by` and `AI-Assisted-By: Hermes Agent` trailers; a GPG signature is not available in the submission environment. Happy to re-sign if a key can be provided.
- **On-chain identity:** the AssetHub address above is a freshly provisioned self-custody address; registrar judgement on the People Chain is pending owner setup.
- **This is the only open PR for this account** in this repository.
