### PR TITLE
fix: Use lowercase 'here' key in PJS getDryRunXcm

### DIFF
--- a/packages/sdk-pjs/src/PolkadotJsApi.test.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.test.ts
@@ -1244,7 +1244,7 @@ describe('PolkadotJsApi', () => {
     const hereForwarded = [
       [
         {
-          v4: { parents: 0, interior: { Here: null } }
+          v4: { parents: 0, interior: { here: null } }
         }
       ]
     ] as unknown as object[]
@@ -1392,7 +1392,7 @@ describe('PolkadotJsApi', () => {
         asset: dotAsset,
         weight: { refTime: 1000n, proofSize: 2000n },
         forwardedXcms: expect.any(Object),
-        destParaId: undefined
+        destParaId: 0
       })
     })
 
@@ -1674,7 +1674,7 @@ describe('PolkadotJsApi', () => {
         asset: feeAsset,
         weight: { refTime: 555n, proofSize: 666n },
         forwardedXcms: expectedForwarded,
-        destParaId: undefined
+        destParaId: 0
       })
 
       paymentInfoSpy.mockRestore()
@@ -2085,7 +2085,7 @@ describe('PolkadotJsApi', () => {
                 {
                   v4: {
                     parents: 0,
-                    interior: { Here: null }
+                    interior: { here: null }
                   }
                 }
               ]
@@ -2121,7 +2121,8 @@ describe('PolkadotJsApi', () => {
           refTime: 111n,
           proofSize: 222n
         },
-        forwardedXcms: expect.any(Object)
+        forwardedXcms: expect.any(Object),
+        destParaId: 0
       })
     })
 

--- a/packages/sdk-pjs/src/PolkadotJsApi.ts
+++ b/packages/sdk-pjs/src/PolkadotJsApi.ts
@@ -697,7 +697,7 @@ class PolkadotJsApi<TCustomChain extends string = never> extends PolkadotApi<
     const destParaId =
       forwardedXcms.length === 0
         ? undefined
-        : (i => (i.Here ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
+        : (i => (i.here === null ? 0 : (Array.isArray(i.x1) ? i.x1[0] : i.x1)?.parachain))(
             Object.values<any>(forwardedXcms[0])[0].interior
           )
 


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2051

---

## 🛠️ Description of the Fix

- **Bug description:** The PJS (PolkadotJS) API backend in `PolkadotJsApi.ts` serializes XCM junctions to lowercase keys in its `toJSON()` output (e.g., `{ interior: { here: null } }`). However, the `getDryRunXcm` method on line 700 checked `i.Here` (uppercase `H`), which **never matches** the actual serialized output. This meant relay-chain destinations (the `here` junction) were silently skipped during dry-run fee estimation, causing `destParaId` to fall through and return `undefined` instead of `0`.

  Note: As the maintainer pointed out in the issue, the correct key is `i.here` (lowercase), not `i.Here`. The PAPI and Dedot backends already handle this correctly — this was a PJS-only bug.

- **Fix summary:** Changed `i.Here` to `i.here === null` on line 700, consistent with the existing correct usage on line 444 (which already used lowercase). Updated the test fixtures to use lowercase `here` matching real PJS `toJSON()` behavior, and corrected the expected `destParaId` from `undefined` to `0`.

---

## ✅ Contributor Eligibility

- [x] My GitHub account's commit history is at least 6 months old.
- [x] I have set an on-chain identity on the Polkadot People Chain for my AssetHub address and requested a registrar judgement of at least `Reasonable` (verifiable via [Subscan](https://people-polkadot.subscan.io/)).
- [x] Every commit in this PR is signed (`-S`) and includes `Signed-off-by` and `AI-Assisted-By: <tool name(s)>` (or `AI-Assisted-By: None`) trailers.
- [x] I disclose any AI tools used to help write this fix (or confirm none were used), and I understand and can explain/defend the resulting code myself.
- [x] This fix was authored and reviewed by a human — not opened autonomously by an AI agent.
- [x] I will respond to maintainer review questions with specific, on-topic answers within 5 days.
- [x] I understand 🔴 High complexity fixes may require a brief live chat/call walkthrough before payout.
- [x] This is the only bug bounty issue I currently have reserved.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective (if applicable).
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `16epYi2zGsDq6fsrJeJsUiFGtYfFxdHre5yPpHXdVcu84AbP`

---

## 🧩 Additional Notes

This is a 1-line code fix plus test fixture updates. The lowercase `here` key matches what PJS actually produces in `toJSON()` output, and is consistent with the existing `getDryRunCall` method on line 444 which already used the correct casing.

@michaeldev5