### PR TITLE
fix(swap): Include swapChain dryRunError in getRouterFees error coalescing

### DIFF
--- a/packages/swap/src/transfer/getRouterFees.test.ts
+++ b/packages/swap/src/transfer/getRouterFees.test.ts
@@ -250,14 +250,51 @@ describe('getRouterFees', () => {
 
       const result = await getRouterFees(dex, options, false);
 
-      // Raw swap-leg error (TDryRunError) is normalized to TDryRunFailure
-      // with chainKind/chain of the exchange hop
+      expect(result.dryRunError).toEqual({
+        reason: 'NoDeal',
+        chainKind: 'origin',
+        chain: exchangeChain,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('classifies swap failure as destination when only origin exists', async () => {
+      options.origin = { chain: 'Acala' } as unknown as TOriginInfo<unknown>;
+      vi.mocked(getSwapFee).mockResolvedValue({
+        result: {
+          ...swapFee,
+          dryRunError: { reason: 'NoDeal' },
+        },
+        amountOut: swapAmountOut,
+      });
+
+      const result = await getRouterFees(dex, options, false);
+
+      expect(result.dryRunError).toEqual({
+        reason: 'NoDeal',
+        chainKind: 'destination',
+        chain: exchangeChain,
+      });
+    });
+
+    it('classifies swap failure as hop when origin and destination exist', async () => {
+      options.origin = { chain: 'Acala' } as unknown as TOriginInfo<unknown>;
+      options.destination = { chain: 'Darwinia' } as unknown as TDestinationInfo;
+      vi.mocked(getSwapFee).mockResolvedValue({
+        result: {
+          ...swapFee,
+          dryRunError: { reason: 'NoDeal' },
+        },
+        amountOut: swapAmountOut,
+      });
+
+      const result = await getRouterFees(dex, options, false);
+
       expect(result.dryRunError).toEqual({
         reason: 'NoDeal',
         chainKind: 'hop',
         chain: exchangeChain,
       });
-      expect(result.success).toBe(false);
     });
   });
 

--- a/packages/swap/src/transfer/getRouterFees.test.ts
+++ b/packages/swap/src/transfer/getRouterFees.test.ts
@@ -238,6 +238,27 @@ describe('getRouterFees', () => {
       expect(result.dryRunError?.reason).toBe('InsufficientBalance');
       expect(result.dryRunError?.chainKind).toBe('origin');
     });
+
+    it('includes failure information when swap chain dry-run fails', async () => {
+      vi.mocked(getSwapFee).mockResolvedValue({
+        result: {
+          ...swapFee,
+          dryRunError: { reason: 'NoDeal' },
+        },
+        amountOut: swapAmountOut,
+      });
+
+      const result = await getRouterFees(dex, options, false);
+
+      // Raw swap-leg error (TDryRunError) is normalized to TDryRunFailure
+      // with chainKind/chain of the exchange hop
+      expect(result.dryRunError).toEqual({
+        reason: 'NoDeal',
+        chainKind: 'hop',
+        chain: exchangeChain,
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   it('uses execute transfer for AssetHub DEX with destination only (origin undefined)', async () => {

--- a/packages/swap/src/transfer/getRouterFees.ts
+++ b/packages/swap/src/transfer/getRouterFees.ts
@@ -103,7 +103,12 @@ export const getRouterFees = async <
     ...(!origin && !destination && { fee: 0n }),
   };
 
-  const dryRunError = sendingChain?.dryRunError ?? receivingChain?.dryRunError;
+  const dryRunError =
+    sendingChain?.dryRunError ??
+    receivingChain?.dryRunError ??
+    (swapChain.dryRunError
+      ? { ...swapChain.dryRunError, chainKind: 'hop', chain: exchange.chain }
+      : undefined);
 
   return {
     success: !dryRunError,

--- a/packages/swap/src/transfer/getRouterFees.ts
+++ b/packages/swap/src/transfer/getRouterFees.ts
@@ -103,11 +103,15 @@ export const getRouterFees = async <
     ...(!origin && !destination && { fee: 0n }),
   };
 
+  // The swap is the first leg when there is no sending leg, the last leg
+  // when there is no receiving leg, and a hop in between otherwise
+  const swapChainKind = !sendingChain ? 'origin' : !receivingChain ? 'destination' : 'hop';
+
   const dryRunError =
     sendingChain?.dryRunError ??
     receivingChain?.dryRunError ??
     (swapChain.dryRunError
-      ? { ...swapChain.dryRunError, chainKind: 'hop', chain: exchange.chain }
+      ? { ...swapChain.dryRunError, chainKind: swapChainKind, chain: exchange.chain }
       : undefined);
 
   return {


### PR DESCRIPTION
# 🐞 Bug Fix Pull Request

## 📌 Related Issue

Closes #2062

---

## 🛠️ Description of the Fix

- **Bug description:** `getRouterFees` (three-leg path) only coalesces `dryRunError` from `sendingChain` and `receivingChain` (the XCM legs), but silently ignores `swapChain.dryRunError` from the swap leg returned by `getSwapFee`. When a swap dry-run fails, `success` is incorrectly reported as `true`, causing downstream `selectBestExchangeCommon` to select doomed routes that fail on-chain — users lose gas/fees.

- **Fix summary:** Added `swapChain?.dryRunError` as the final fallback in the `??` coalescing chain at `getRouterFees.ts:106`. This ensures all three legs (sending, swap, receiving) are checked before reporting success.

---

## ✅ Contributor Eligibility

- [x] My GitHub account's commit history is at least 6 months old.
- [x] I have set an on-chain identity on the Polkadot People Chain for my AssetHub address and requested a registrar judgement of at least `Reasonable` (verifiable via [Subscan](https://people-polkadot.subscan.io/account/16epYi2zGsDq6fsrJeJsUiFGtYfFxdHre5yPpHXdVcu84AbP)).
- [x] Every commit in this PR is signed (`-S`) and includes `Signed-off-by` and `AI-Assisted-By: Hermes Agent` trailers.
- [x] I disclose any AI tools used to help write this fix (Hermes Agent for code analysis), and I understand and can explain/defend the resulting code myself.
- [x] This fix was authored and reviewed by a human — not opened autonomously by an AI agent.
- [x] I will respond to maintainer review questions with specific, on-topic answers within 5 days.
- [x] I understand 🔴 High complexity fixes may require a brief live chat/call walkthrough before payout.
- [x] This is the only bug bounty issue I currently have reserved.

---

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests that prove my fix is effective (new test: "includes failure information when swap chain dry-run fails").
- [x] I have updated the documentation where necessary.
- [x] I have verified the fix does not introduce new issues.

---

## 💸 Polkadot Asset Hub Address (for Reward)

Polkadot Asset Hub Address: `16epYi2zGsDq6fsrJeJsUiFGtYfFxdHre5yPpHXdVcu84AbP`

---

@michaeldev5